### PR TITLE
Init:  절대 경로 & 오토 리뷰어 설정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@Passtival/Passtival-FE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@Passtival/Passtival-FE
+* @Passtival/Passtival-FE

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -35,6 +35,13 @@ export default tseslint.config([
             'internal',
             ['parent', 'sibling', 'index'],
           ],
+          pathGroups: [
+            { pattern: '@layout/**', group: 'internal', position: 'after' },
+            { pattern: '@pages/**', group: 'internal', position: 'after' },
+            { pattern: '@routes/**', group: 'internal', position: 'after' },
+            { pattern: '@shared/**', group: 'internal', position: 'after' },
+          ],
+          pathGroupsExcludedImportTypes: ['builtin'],
           alphabetize: { order: 'asc', caseInsensitive: true },
           'newlines-between': 'always',
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "prettier": "^3.6.2",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       vite:
         specifier: ^7.0.4
         version: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0))
 
 packages:
 
@@ -1230,6 +1233,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1922,6 +1928,16 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -1976,6 +1992,14 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@7.0.6:
     resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
@@ -3357,6 +3381,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graphemer@1.4.0: {}
@@ -4046,6 +4072,10 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  tsconfck@3.1.6(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -4123,6 +4153,17 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0)):
+    dependencies:
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.8.3)
+    optionalDependencies:
+      vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "paths": {
       "@layout/*": ["src/layout/*"],
       "@pages/*": ["src/pages/*"],
-      "routes/*": ["src/routes/*"],
-      "shared/*": ["src/shared/*"]
+      "@routes/*": ["src/routes/*"],
+      "@shared/*": ["src/shared/*"]
     }
   },
   "files": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,13 @@
 {
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@layout/*": ["src/layout/*"],
+      "@pages/*": ["src/pages/*"],
+      "routes/*": ["src/routes/*"],
+      "shared/*": ["src/shared/*"]
+    }
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,17 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import path from 'path';
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      '@layout': path.resolve(__dirname, './src/layout'),
+      '@pages': path.resolve(__dirname, './src/pages'),
+      '@routes': path.resolve(__dirname, './src/routes'),
+      '@shared': path.resolve(__dirname, './src/shared'),
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,8 @@
-import path from 'path';
-
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@layout': path.resolve(__dirname, './src/layout'),
-      '@pages': path.resolve(__dirname, './src/pages'),
-      '@routes': path.resolve(__dirname, './src/routes'),
-      '@shared': path.resolve(__dirname, './src/shared'),
-    },
-  },
+  plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
## 💬 Describe

> #18 

절대 경로는 import 경로를 간단하고 직관적으로 작성할 수 있도록 별칭을 지정하는 기능입니다. 상대경로(../../../) 대신 @pages, @shared와 같은 별칭을 사용해 가독성과 유지보수성을 높입니다.
**설정 전**
import Button from '../../../../shared/components/Button';
**설정 후**
import Button from '@shared/components/Button';

오토 리뷰어는 PR 생성 시 리뷰어를 자동으로 지정함으로써 수동 지정의 번거로움을 줄이고, 리뷰 누락을 방지하여 협업 효율을 높이기 위해 오토 리뷰어를 설정했습니다.

## 📑 Task

**절대 경로**
- tsconfig.json의 compilerOptions.paths에 @layout, @pages, @routes, @shared 절대경로 추가
- vite.config.ts에서 vite-tsconfig-paths 플러그인 사용 → tsconfig.json의 paths를 자동으로 Vite에 적용
- ESLint의 import/order 규칙에 alias 순서를 반영하여 저장 시 자동 정렬되도록 설정

**오토 리뷰어**
- .github/CODEOWNERS 파일 생성
- 모든 파일(*)에 대해 @Passtival/Passtival-FE 팀을 자동 리뷰어로 지정

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->

<!--
## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
-->
