### PR TITLE
Feat: 모달 컴포넌트 구현

### DIFF
--- a/src/shared/components/modal/hooks/use-scroll-lock.ts
+++ b/src/shared/components/modal/hooks/use-scroll-lock.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+export const useScrollLock = (locked: boolean) => {
+  useEffect(() => {
+    if (!locked) return;
+
+    const prevStyle = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = prevStyle || 'unset';
+    };
+  }, [locked]);
+};

--- a/src/shared/components/modal/modal.css.ts
+++ b/src/shared/components/modal/modal.css.ts
@@ -1,0 +1,105 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@shared/styles';
+
+export const container = recipe({
+  base: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: themeVars.zIndex.modal,
+
+    background: 'var(--bg_white_10, rgba(255, 255, 255, 0.10))',
+    backdropFilter: 'blur(2.5px)',
+
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  variants: {
+    open: {
+      true: {
+        opacity: 1,
+      },
+      false: {
+        opacity: 0,
+      },
+    },
+  },
+
+  defaultVariants: {
+    open: false,
+  },
+});
+
+export const buttonBase = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  padding: '1.2rem 0',
+
+  flex: 1,
+  color: themeVars.color.main_blue,
+});
+
+export const alignText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+});
+
+export const content = style({
+  display: 'flex',
+  width: '27rem',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  backgroundColor: themeVars.color.gray_200,
+  borderRadius: '14px',
+  boxShadow: '0 0 32px 0 rgba(0, 0, 0, 0.20)',
+  backdropFilter: 'blur(25px)',
+});
+
+export const body = style([
+  alignText,
+  { padding: '2rem 1.6rem', gap: '0.4rem' },
+]);
+
+export const summary = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const infoSection = style([alignText]);
+
+export const title = style({
+  ...themeVars.fontStyles.button2_sb_16,
+  color: themeVars.color.gray_900,
+});
+
+export const modalBodyText = style({
+  ...themeVars.fontStyles.button_r_14,
+  color: themeVars.color.gray_600,
+});
+
+export const footer = style({
+  display: 'flex',
+  width: '100%',
+
+  borderTop: `0.333px solid ${themeVars.color.gray_600}`,
+});
+
+export const closeButton = style([
+  buttonBase,
+  themeVars.fontStyles.button_r_14,
+]);
+
+export const actionButton = style([
+  buttonBase,
+  themeVars.fontStyles.button2_sb_14,
+  { borderLeft: `0.333px solid ${themeVars.color.gray_600}` },
+]);

--- a/src/shared/components/modal/modal.css.ts
+++ b/src/shared/components/modal/modal.css.ts
@@ -71,7 +71,7 @@ export const body = style([
 export const summary = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: '1rem',
+  gap: '1.2rem',
 });
 
 export const infoSection = style([alignText]);

--- a/src/shared/components/modal/modal.tsx
+++ b/src/shared/components/modal/modal.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from 'react';
+
+import { useScrollLock } from '@shared/components/modal/hooks/use-scroll-lock';
+
+import * as styles from './modal.css';
+
+interface ContainerProps {
+  children: ReactNode;
+  open: boolean;
+}
+
+interface ContentProps {
+  children: ReactNode;
+}
+
+interface BodyProps {
+  children: ReactNode;
+}
+
+interface TitleProps {
+  children: ReactNode;
+}
+
+interface SummaryProps {
+  children: ReactNode;
+}
+
+interface InfoSectionProps {
+  children: ReactNode;
+}
+
+interface InfoProps {
+  label: string;
+  value: string;
+}
+
+interface DescriptionProps {
+  children: ReactNode;
+}
+
+interface FooterProps {
+  children: ReactNode;
+}
+
+interface CloseProps {
+  children: ReactNode;
+  onClick: () => void;
+}
+
+interface ActionProps {
+  children: ReactNode;
+  onClick: () => void;
+}
+
+const Container = ({ children, open }: ContainerProps) => {
+  useScrollLock(open);
+  return <div className={styles.container({ open })}>{children}</div>;
+};
+
+const Content = ({ children }: ContentProps) => {
+  return <div className={styles.content}>{children}</div>;
+};
+
+const Body = ({ children }: BodyProps) => {
+  return <div className={styles.body}>{children}</div>;
+};
+
+const Title = ({ children }: TitleProps) => {
+  return <h1 className={styles.title}>{children}</h1>;
+};
+
+const Summary = ({ children }: SummaryProps) => {
+  return <section className={styles.summary}>{children}</section>;
+};
+
+const InfoSection = ({ children }: InfoSectionProps) => {
+  return <section className={styles.infoSection}>{children}</section>;
+};
+
+const Info = ({ label, value }: InfoProps) => {
+  return (
+    <p className={styles.modalBodyText}>
+      {label} - {value}
+    </p>
+  );
+};
+
+const Description = ({ children }: DescriptionProps) => {
+  return <p className={styles.modalBodyText}>{children}</p>;
+};
+
+const Footer = ({ children }: FooterProps) => {
+  return <div className={styles.footer}>{children}</div>;
+};
+
+const Close = ({ children, onClick }: CloseProps) => {
+  return (
+    <button
+      className={styles.closeButton}
+      type="button"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+const Action = ({ children, onClick }: ActionProps) => {
+  return (
+    <button
+      className={styles.actionButton}
+      type="button"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+const Modal = {
+  Container,
+  Content,
+  Body,
+  Title,
+  Summary,
+  InfoSection,
+  Info,
+  Description,
+  Footer,
+  Close,
+  Action,
+};
+
+export default Modal;


### PR DESCRIPTION
## 💬 Describe

> - #26 

해당 PR에 대해 설명해 주세요.
- 모달 컴포넌트 구현

## 📑 Task
모달 컴포넌트를 구현하기 전 각 페이지마다 모달의 버튼수, 주입되는 값이 차이가 많이 난다는것을 발견했어요. 그래서 이번에는 Compound Pattern을 사용하여 모달 컴포넌트를 구현해보았습니다.



## Compound Pattern
- 컴파운드 패턴은 Modal.Container, Modal.Body, Modal.Footer와 같이 계층적으로 선언할 수 있어 마크업 구조가 자연스럽게 드러나는 장점이 있어 가독성이 향상하는 장점이 있어요. 그리고 내부 요소들(제목, 설명 등등)을 별도 컴포넌트로 분리해서 관심사를 분리할 수 있어요. 따라서 불필요한 props drilling을 하지 않고 필요한 UI만 선택적으로 사용 가능하다는 장점이 있습니다.
- 그리고 모달에 컴파운드 패턴을 선택한 이유 중 하나는 확장성과 유연성 때문이에요. 컴파운드 패턴을 사용해서 모달 내부의 컴포넌트를 자유롭게 조합하여 사용할 수 있도록 했어요.  
<img width="878" height="468" alt="image" src="https://github.com/user-attachments/assets/55e93e67-2eb1-42e5-9f58-d35a0204281c" />


사진을 보면 
- 버튼의 갯수
- 제목 밑 description이 필요할때
- description과 info(인스타그램 ID나 전화번호, 이름, 학번 등)이 함께 필요할때

이러한 상황을 고려해서 필요한 부분만 페이지에서 사용하도록 설계를 해봤어요.

## [사용법]
모달 컴포넌트는 크게 `응모권 조회 페이지`, `분실물 페이지`, `번호팅 페이지` 이렇게 세 곳에서 사용돼요.

- Modal.Container에 페이지에서 open의 상태를 관리하며 상태값을 주입시킵니다.
- 각 페이지에서 필요한 모달에 맞게 사용하시면 됩니다.
- 단순 설명을 하는 페이지라면 Modal.InfoSection은 안 쓰셔도 돼요.
- 버튼이 취소, 확인 버튼만 있다면 Modal.Action은 안 쓰셔도 됩니다.

```ts
<Modal.Container open={open}>
  <Modal.Content>
    <Modal.Body>
      <Modal.Title>신청하시겠습니까?</Modal.Title>
      <Modal.Summary>
        {/* <Modal.InfoSection>                                      -> 전화번호, 인스타그램 아이디 등
          {infoItems.map(({ label, value }) => (
            <Modal.Info
              key={label}
              label={label}
              value={value}
            />
          ))}
        </Modal.InfoSection> */}
        <Modal.Description>
          *18시에 매칭결과가 제공됩니다.
        </Modal.Description>
      </Modal.Summary>
    </Modal.Body>
    <Modal.Footer>
      <Modal.Close onClick={() => setOpen(false)}>취소</Modal.Close>        ->  취소, 확인버튼
      {/* <Modal.Action onClick={() => {}}>신청하기</Modal.Action> */}        -> 삭제하기, 신청하기 버튼
    </Modal.Footer>
  </Modal.Content>
</Modal.Container>
```

## useScrollLock 커스텀훅 구현
Modal.Container에서 모달이 open 상태가 되었을 때 useScrollLock 커스텀훅을 호출하여 모달이 켜졌을 때 뒷 배경 스크롤을 막기 위한 커스텀훅을 제작하였습니다.

## 🙋🏻‍♂️ Request
~현재 Modal.InfoSection과 Modal.Description의 사이 간격이 정해지지 않아 디자인분들에게 요청한 상태입니다. 반영이 되면 한번 더 알려드릴게요!~

## 📸 Screenshot
<details>
<summary>영상보기</summary>

![화면 기록 2025-08-18 오전 4 06 36](https://github.com/user-attachments/assets/19e783b6-bc63-4147-a494-4a152b576ede)


</details>
<img width="568" height="390" alt="image" src="https://github.com/user-attachments/assets/814dd64d-c2f3-4ec6-891e-68add8394ed6" />
<img width="552" height="377" alt="image" src="https://github.com/user-attachments/assets/0d149315-07a0-4a36-8b2b-caf4a97e3083" />
<img width="544" height="286" alt="image" src="https://github.com/user-attachments/assets/5bd90da7-cc16-440c-80b5-a2e6c32b3626" />
