### PR TITLE
Feat: Card 컴포넌트 구현

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -7,18 +7,29 @@ function Home() {
 
   return (
     <div>
-      <Card onClick={() => handleCardClick('우가우가신석기시대')}>
-        <Card.Title>우가우가신석기시대</Card.Title>
-        <Card.Major>글로벌경영학과</Card.Major>
-        <Card.MajortTxt>우가우가! 신석기가 최고야!</Card.MajortTxt>
-        <Card.Image src="https://example.com/image1.png" />
-      </Card>
+      <Card.Container onClick={() => handleCardClick('우가우가신석기시대')}>
+        <Card.Content>
+          <Card.Title>우가우가신석기시대</Card.Title>
+          <Card.Major>글로벌경영학과</Card.Major>
+          <Card.MajortTxt>
+            우가우가!우가ㅜ아구ㅏ우ㅏㅜ아 신석기가 최고야!
+          </Card.MajortTxt>
+        </Card.Content>
+        <Card.Img src="" />
+      </Card.Container>
 
-      <Card onClick={() => handleCardClick('검정색 똥')}>
-        <Card.Title>검정색 똥</Card.Title>
-        <Card.lostTxt>이런거 보관하면 안되겠죠?</Card.lostTxt>
-        <Card.Image src="https://example.com/image2.png" />
-      </Card>
+      <Card.Container
+        size="lg"
+        onClick={() => handleCardClick('검정색 똥')}
+      >
+        <Card.Content>
+          <Card.Title>검정색 똥밥바바바바바바바바바바바바</Card.Title>
+          <Card.LostTxt>
+            안녕하세요카드만들었어요안녕하세요카드만들었어요안녕하세요카드만들었어요안녕하세요카드만들었어요안녕하세요카드만들었어요안녕하세요카드만들었어요
+          </Card.LostTxt>
+        </Card.Content>
+        <Card.Img src="" />
+      </Card.Container>
     </div>
   );
 }

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,5 +1,26 @@
-const Home = () => {
-  return <div>Home</div>;
-};
+import Card from '@shared/components/card/card';
+
+function Home() {
+  const handleCardClick = (title: string) => {
+    alert(`${title} 카드가 클릭되었습니다!`);
+  };
+
+  return (
+    <div>
+      <Card onClick={() => handleCardClick('우가우가신석기시대')}>
+        <Card.Title>우가우가신석기시대</Card.Title>
+        <Card.Major>글로벌경영학과</Card.Major>
+        <Card.MajortTxt>우가우가! 신석기가 최고야!</Card.MajortTxt>
+        <Card.Image src="https://example.com/image1.png" />
+      </Card>
+
+      <Card onClick={() => handleCardClick('검정색 똥')}>
+        <Card.Title>검정색 똥</Card.Title>
+        <Card.lostTxt>이런거 보관하면 안되겠죠?</Card.lostTxt>
+        <Card.Image src="https://example.com/image2.png" />
+      </Card>
+    </div>
+  );
+}
 
 export default Home;

--- a/src/shared/components/card/card.css.ts
+++ b/src/shared/components/card/card.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { themeVars } from '@shared/styles';
+import { width } from '@shared/styles/token/width.css';
+
+export const card = style({
+  width: '32.1rem',
+  height: '13.3rem',
+
+  backgroundColor: themeVars.color.sub_blue_40,
+  boxShadow: '2px 2px 5px rgba(24, 118, 250, 0.20)',
+
+  borderRadius: '10px',
+});
+export const title = style({
+  ...themeVars.fontStyles.title_b_18,
+  padding: '1.4rem 1.1rem 0 1.5rem',
+});
+export const major = style({
+  ...themeVars.fontStyles.title_b_14,
+  color: themeVars.color.main_blue,
+  padding: '0 1.1rem 0.5rem 1.5rem',
+});
+export const majortxt = style({
+  ...themeVars.fontStyles.caption2_m_12,
+  color: themeVars.color.gray_600,
+  padding: '0 3rem 0 1.5rem',
+});
+export const losttxt = style({
+  ...themeVars.fontStyles.body1_r_15,
+  color: themeVars.color.gray_600,
+  padding: '0 1.1rem 0 1.6rem',
+});
+export const img = style({});

--- a/src/shared/components/card/card.css.ts
+++ b/src/shared/components/card/card.css.ts
@@ -2,34 +2,83 @@ import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@shared/styles';
-import { width } from '@shared/styles/token/width.css';
 
-export const card = style({
-  width: '32.1rem',
-  height: '13.3rem',
+export const card = recipe({
+  base: {
+    display: 'flex',
+    justifyContent: 'space-between',
 
-  backgroundColor: themeVars.color.sub_blue_40,
-  boxShadow: '2px 2px 5px rgba(24, 118, 250, 0.20)',
+    backgroundColor: themeVars.color.sub_blue_40,
+    boxShadow: '2px 2px 5px rgba(24, 118, 250, 0.20)',
 
-  borderRadius: '10px',
+    borderRadius: '10px',
+  },
+
+  variants: {
+    size: {
+      sm: {
+        width: '32.1rem',
+        height: '13.3rem',
+      },
+      lg: {
+        width: '34.5rem',
+        height: '13.3rem',
+      },
+    },
+  },
 });
-export const title = style({
+
+export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '16rem',
+
+  overflow: 'hidden',
+
+  textOverflow: 'ellipsis',
+});
+
+export const titlesm = style({
+  width: '16rem',
+  height: '2.7rem',
   ...themeVars.fontStyles.title_b_18,
-  padding: '1.4rem 1.1rem 0 1.5rem',
+  margin: '1.4rem 1.1rem 0 1.5rem',
+
+  whiteSpace: 'nowrap',
 });
+
+export const titlelg = style({
+  ...themeVars.fontStyles.title_b_18,
+  margin: '1.4rem 1.1rem 0 1.5rem',
+
+  whiteSpace: 'nowrap',
+});
+
 export const major = style({
   ...themeVars.fontStyles.title_b_14,
   color: themeVars.color.main_blue,
-  padding: '0 1.1rem 0.5rem 1.5rem',
+  margin: '0 1.1rem 0.5rem 1.5rem',
+
+  whiteSpace: 'nowrap',
 });
+
 export const majortxt = style({
   ...themeVars.fontStyles.caption2_m_12,
   color: themeVars.color.gray_600,
-  padding: '0 3rem 0 1.5rem',
+  height: '5.3rem',
+  margin: '0 1.1rem 3.4rem 1.5rem',
 });
+
 export const losttxt = style({
   ...themeVars.fontStyles.body1_r_15,
   color: themeVars.color.gray_600,
-  padding: '0 1.1rem 0 1.6rem',
+  height: '6.4rem',
+  margin: '0 1.1rem 4.1rem 1.6rem',
+  overflow: 'hidden',
 });
-export const img = style({});
+
+export const img = style({
+  width: '11.9rem',
+  height: '10.5rem',
+  margin: '1.2rem 1.6rem 0 0',
+});

--- a/src/shared/components/card/card.tsx
+++ b/src/shared/components/card/card.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode, MouseEvent } from 'react';
+import { createContext } from 'react';
+
+import * as style from './card.css';
+
+const CardContext = createContext({});
+
+interface CardProps {
+  children: ReactNode;
+  onClick: (event: MouseEvent<HTMLDivElement>) => void;
+}
+
+interface ChildProps {
+  children: ReactNode;
+}
+
+interface ImageProps {
+  src: string;
+}
+
+const Card = ({ children, onClick }: CardProps) => {
+  const state = {};
+
+  return (
+    <CardContext.Provider value={state}>
+      {/* 1. div에 onClick 핸들러를 추가합니다. */}
+      {/* 2. 클릭 가능한 요소임을 나타내기 위해 커서를 pointer로 변경합니다. */}
+      <div
+        className={style.card}
+        onClick={onClick}
+      >
+        {children}
+      </div>
+    </CardContext.Provider>
+  );
+};
+
+Card.Title = ({ children }: ChildProps) => {
+  return <p className={style.title}>{children}</p>;
+};
+
+Card.Major = ({ children }: ChildProps) => {
+  return <p className={style.major}>{children}</p>;
+};
+
+Card.MajortTxt = ({ children }: ChildProps) => {
+  return <p className={style.majortxt}>{children}</p>;
+};
+
+Card.lostTxt = ({ children }: ChildProps) => {
+  return <p className={style.losttxt}>{children}</p>;
+};
+
+Card.Image = ({ src }: ImageProps) => {
+  return (
+    <img
+      className={style.img}
+      src={src}
+    />
+  );
+};
+
+export default Card;

--- a/src/shared/components/card/card.tsx
+++ b/src/shared/components/card/card.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode, MouseEvent } from 'react';
-import { createContext } from 'react';
 
-import * as style from './card.css';
-
-const CardContext = createContext({});
+import * as styles from './card.css';
+import { useCard, CardContext } from './hooks/use-card';
 
 interface CardProps {
   children: ReactNode;
+  size?: 'sm' | 'lg';
   onClick: (event: MouseEvent<HTMLDivElement>) => void;
 }
 
@@ -18,15 +17,11 @@ interface ImageProps {
   src: string;
 }
 
-const Card = ({ children, onClick }: CardProps) => {
-  const state = {};
-
+const Container = ({ children, onClick, size = 'sm' }: CardProps) => {
   return (
-    <CardContext.Provider value={state}>
-      {/* 1. div에 onClick 핸들러를 추가합니다. */}
-      {/* 2. 클릭 가능한 요소임을 나타내기 위해 커서를 pointer로 변경합니다. */}
+    <CardContext.Provider value={{ size }}>
       <div
-        className={style.card}
+        className={styles.card({ size })}
         onClick={onClick}
       >
         {children}
@@ -35,29 +30,45 @@ const Card = ({ children, onClick }: CardProps) => {
   );
 };
 
-Card.Title = ({ children }: ChildProps) => {
-  return <p className={style.title}>{children}</p>;
+const Content = ({ children }: ChildProps) => {
+  return <div className={styles.contentContainer}>{children}</div>;
 };
 
-Card.Major = ({ children }: ChildProps) => {
-  return <p className={style.major}>{children}</p>;
+const Title = ({ children }: ChildProps) => {
+  const { size } = useCard();
+  const titleClassName = size === 'lg' ? styles.titlelg : styles.titlesm;
+
+  return <p className={titleClassName}>{children}</p>;
 };
 
-Card.MajortTxt = ({ children }: ChildProps) => {
-  return <p className={style.majortxt}>{children}</p>;
+const Major = ({ children }: ChildProps) => {
+  return <p className={styles.major}>{children}</p>;
 };
 
-Card.lostTxt = ({ children }: ChildProps) => {
-  return <p className={style.losttxt}>{children}</p>;
+const MajortTxt = ({ children }: ChildProps) => {
+  return <p className={styles.majortxt}>{children}</p>;
 };
 
-Card.Image = ({ src }: ImageProps) => {
+const LostTxt = ({ children }: ChildProps) => {
+  return <p className={styles.losttxt}>{children}</p>;
+};
+
+const Img = ({ src }: ImageProps) => {
   return (
     <img
-      className={style.img}
+      className={styles.img}
       src={src}
     />
   );
 };
 
+const Card = {
+  Container,
+  Content,
+  Title,
+  Major,
+  MajortTxt,
+  LostTxt,
+  Img,
+};
 export default Card;

--- a/src/shared/components/card/hooks/use-card.ts
+++ b/src/shared/components/card/hooks/use-card.ts
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+type CardSize = 'sm' | 'lg';
+
+export const CardContext = createContext<{ size?: CardSize }>({});
+
+export const useCard = () => {
+  const { size } = useContext(CardContext);
+  return { size };
+};


### PR DESCRIPTION
## 💬 Describe

> - #58

해당 PR에 대해 설명해 주세요.
Card 객체 안에 `Container`, `Content`, `Title`, `Major`, `MajorTxt`, `LostTxt`, `Img` 정의했습니다. 이렇게 하면 `Card.Container`, `Card.LostTxt`와 같이 조립식으로 다양한 형태의 카드를 쉽게 만들 수 있어 코드 재사용성이 높아집니다. 

Context API를 사용해 Card.Container의 size prop을 하위 컴포넌트에 일일이 props로 전달하지 않고도 접근할 수 있게 합니다. 

Card.Container에 onClick prop을 추가하여 카드 전체에 클릭 이벤트를 적용하였습니다. 

## 📑 Task
카드 종류가 2개로 디자인 되어있어 sm, lg 타입으로 구성했습니다.
메인페이지에서 사용하는 카드 사이즈는 sm, 분실물 페이지에서 사용하는 타입은 lg입니다.
각 페이지별로 사용하는 컴포넌트가 달라 구분해서 사용해야합니다.
**메인** - `Title`, `Major`, `MajorTxt`, `Img` 
**분실물** - `Title`, `LostTxt`, `Img`
(img제외하고 글자 컴포넌트는 꼭 Content로 묶어 사용해야합니다.)


***사용법***
```
import Card from '@shared/components/card/card';

const Home = () = > {
  return (
    <div>
      <Card.Container
        onClick={() => {}}
      >
        <Card.Content>
          <Card.Title>천재되는법</Card.Title>
          <Card.Major>컴퓨터공학과</Card.Major>
          <Card.LostTxt>
            비밀입니다
        <Card.Img src="" />
      </Card.Container>
    </div>
  );
}

export default Home;
```


## 🙋🏻‍♂️ Request
home에 예시 있습니다 머지 전해 꼭 지우겠습니다1

## 📸 Screenshot
<img width="383" height="304" alt="image" src="https://github.com/user-attachments/assets/060ff9df-5ad4-4bc6-89ac-855fde60796f" />
