### PR TITLE
Feat: Image 컴포넌트 구현

### DIFF
--- a/src/shared/components/image/image.css.ts
+++ b/src/shared/components/image/image.css.ts
@@ -14,14 +14,23 @@ export const img = recipe({
     border: `1.5px solid ${themeVars.color.gray_500_40}`,
     objectFit: 'cover',
   },
+
   variants: {
     type: {
-      square: {
+      square_lg: {
         width: '32.7rem',
         height: '21.4rem',
 
         borderRadius: '8px',
       },
+
+      square_sm: {
+        width: '11.9rem',
+        height: '10.5rem',
+
+        borderRadius: '5px',
+      },
+
       circle: {
         width: '15rem',
         height: '15rem',

--- a/src/shared/components/image/image.tsx
+++ b/src/shared/components/image/image.tsx
@@ -3,7 +3,7 @@ import * as styles from './image.css';
 interface ImageProps {
   img: string;
   alt?: string;
-  type: 'square' | 'circle';
+  type: 'square_sm' | 'square_lg' | 'circle';
 }
 const Image = ({ img, alt, type }: ImageProps) => {
   return (


### PR DESCRIPTION
## 💬 Describe

> - #63

부스&분실물 상세 페이지에서 사용 가능한 square, 응모권 페이지에서 사용가능한 circle 이미지 컴포넌트를 만들었습니다.

## 📑 Task


**DetailImgProps**
`img`: 이미지 경로를 받을 수 있도록 string로 설정했습니다.
`alt` :이미지의 접근성을 위한 대체 텍스트를 받을 수 있도록 alt prop을 선택적으로 정의했습니다.

이미지 css에 `objectFit` 속성을 추가하여 이미지가 설정된 크기보다 크거나 작아도 비율이 뭉개지지 않고 올바르게 표시되도록 했습니다.

**사용 방법**
 ```
return (
    <div className={styles.container}>
      <img
        className={styles.img}
        src={img} 
        alt={alt} //선택사항
        type="circle"
      />
    </div>
  );
```

type: 'square_sm' | 'square_lg' | 'circle';
- square_sm : card 컴포넌트에서 사용되는 작은 이미지
- square_lg : 상세 페이지에서 사용되는 이미지
- circle : 응모권 페이지에서 사용되는 이미지

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->

## 📸 Screenshot
<img width="359" height="241" alt="image" src="https://github.com/user-attachments/assets/9a12a8e4-4935-4cfa-b6c5-983b894930fb" />

<img width="385" height="365" alt="image" src="https://github.com/user-attachments/assets/e09e0f96-25c2-4d9c-b6fb-83ca4a40fb32" />

<img width="402" height="443" alt="image" src="https://github.com/user-attachments/assets/387cf73a-a464-456a-a452-7ea75129b1b0" />

