### PR TITLE
Feat: 부스 의료 정보 페이지

### DIFF
--- a/src/pages/medical/medical.tsx
+++ b/src/pages/medical/medical.tsx
@@ -1,0 +1,50 @@
+import DetailDescription from '@shared/components/detail-desctipion/detail-description';
+import DetailInfo from '@shared/components/detail-eventinfo/detail-info';
+import DetailHeader from '@shared/components/detail-header/detail-header';
+import Thumbnail from '@shared/components/Thumbnail/Thumbnail';
+
+const medicalMock = {
+  subTitle: '의료 도움',
+  title: '의료 지원국',
+  time: '15:00 ~ 16:00',
+  location: '20번',
+  message:
+    '응급 상황을 대비를 위한 공간입니다. 꼭 필요한 상황에 이용해 주세요!',
+  description1:
+    '응급 상황이나 사고 발생 시 간단한 처치를 받을 수 있는 의료지원 부스입니다. 구급약 얼음팩, 붕대 등이 구비되어 있으며 간단한 도움 요청이 가능합니다.',
+  description2:
+    '안양대학교 건강지원센터(비 501) 031-467-0795 응급 의료 상담 119',
+};
+
+const Medical = () => {
+  return (
+    <>
+      <DetailHeader
+        subTitle={medicalMock.subTitle}
+        title={medicalMock.title}
+      />
+      <Thumbnail
+        src=""
+        alt=""
+        type="square_lg"
+      />
+      <DetailInfo
+        time="운영시간"
+        timevalue={medicalMock.time}
+        location="부스위치"
+        locationvalue={medicalMock.location}
+        message={medicalMock.message}
+      />
+      <DetailDescription
+        title="부스 소개"
+        description={medicalMock.description1}
+      />
+      <DetailDescription
+        title="응급 연락처"
+        description={medicalMock.description1}
+      />
+    </>
+  );
+};
+
+export default Medical;

--- a/src/router/lazy.ts
+++ b/src/router/lazy.ts
@@ -18,3 +18,4 @@ export const LoginFallbackPage = lazy(
 export const AdminLoginPage = lazy(
   () => import('@pages/admin-login/admin-login'),
 );
+export const MedicalPage = lazy(() => import('@pages/medical/medical'));

--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -9,6 +9,7 @@ export const routePath = {
   LOST_ITEMS: '/lost-items',
   TICKET: '/ticket',
   ADMIN_LOGIN: '/admin-login',
+  MEDICAL: '/booth/medical',
 } as const;
 
 export type Routes = (typeof routePath)[keyof typeof routePath];

--- a/src/router/routes/global-routes.tsx
+++ b/src/router/routes/global-routes.tsx
@@ -9,6 +9,7 @@ import {
   TicketPage,
   LoginFallbackPage,
   AdminLoginPage,
+  MedicalPage,
 } from '../lazy';
 import { routePath } from '../path';
 
@@ -25,6 +26,7 @@ export const publicRoutesOthers = [
   { path: routePath.LAND, Component: LandPage },
   { path: routePath.ADMIN_LOGIN, Component: AdminLoginPage },
   { path: routePath.SHOW_DETAIL, Component: ShowDetailPage },
+  { path: routePath.MEDICAL, Component: MedicalPage },
 ];
 
 export const protectedRoutes = [


### PR DESCRIPTION
## 💬 Describe

> - #94

해당 PR에 대해 설명해 주세요.
부스 정보 페이지의 `의료지원` chip을 누르면 나오는 의료 정보 페이지 입니다.

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.

- MEDICAL_PAGE 라우팅 설정을 했습니다.
- `DetailHeader`, `Thumnail`, `DetailInfo`, `DetailDescription` 컴포넌트를 사용했습니다.

`DetailHeader` 의료도움, 의료지원국
`Thumbnail` 이미지
`DetailInfo` 운영시간과 부스위치
`DetailDescription` 부스소개와 응급연락처

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="363" height="647" alt="image" src="https://github.com/user-attachments/assets/a6f8e4d7-4dfd-47f3-aced-a0cff26929af" />