### PR TITLE
Feat: 분실물 상세 정보 페이지 구현

### DIFF
--- a/src/pages/lost-item-info/lost-item-info.css.ts
+++ b/src/pages/lost-item-info/lost-item-info.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({ padding: '1.6rem 0 0 0 ' });

--- a/src/pages/lost-item-info/lost-item-info.tsx
+++ b/src/pages/lost-item-info/lost-item-info.tsx
@@ -3,6 +3,8 @@ import { useParams } from 'react-router';
 import Carousel from '@shared/components/carousel/carousel';
 import DetailInfo from '@shared/components/detail-eventinfo/detail-info';
 
+import * as styles from './lost-item-info.css';
+
 const mockImages = ['안녕하세요', '두번째', '내가 잃어버린 초코파이'];
 
 const InfoMock = {
@@ -17,7 +19,7 @@ const LostItemsInfo = () => {
   const { id } = useParams();
   const mockData = InfoMock[id as keyof typeof InfoMock];
   return (
-    <>
+    <div className={styles.container}>
       <Carousel type="details">
         {mockImages.map((imageUrl, index) => (
           <img
@@ -34,7 +36,7 @@ const LostItemsInfo = () => {
         location="습득위치"
         locationvalue={mockData.locationvalue}
       />
-    </>
+    </div>
   );
 };
 export default LostItemsInfo;

--- a/src/pages/lost-item-info/lost-item-info.tsx
+++ b/src/pages/lost-item-info/lost-item-info.tsx
@@ -1,15 +1,21 @@
+import { useParams } from 'react-router';
+
 import Carousel from '@shared/components/carousel/carousel';
 import DetailInfo from '@shared/components/detail-eventinfo/detail-info';
 
 const mockImages = ['안녕하세요', '두번째', '내가 잃어버린 초코파이'];
 
 const InfoMock = {
-  title: '100만원',
-  timevalue: '9/23 15:00',
-  locationvalue: '3번째 소나무 5번째 뿌리',
+  '1': {
+    title: '100만원',
+    timevalue: '9/23 15:00',
+    locationvalue: '3번째 소나무 5번째 뿌리',
+  },
 };
 
 const LostItemsInfo = () => {
+  const { id } = useParams();
+  const mockData = InfoMock[id as keyof typeof InfoMock];
   return (
     <>
       <Carousel type="details">
@@ -22,11 +28,11 @@ const LostItemsInfo = () => {
         ))}
       </Carousel>
       <DetailInfo
-        title={InfoMock.title}
+        title={mockData.title}
         time="습득시간"
-        timevalue={InfoMock.timevalue}
+        timevalue={mockData.timevalue}
         location="습득위치"
-        locationvalue={InfoMock.locationvalue}
+        locationvalue={mockData.locationvalue}
       />
     </>
   );

--- a/src/pages/lost-item-info/lost-item-info.tsx
+++ b/src/pages/lost-item-info/lost-item-info.tsx
@@ -1,0 +1,34 @@
+import Carousel from '@shared/components/carousel/carousel';
+import DetailInfo from '@shared/components/detail-eventinfo/detail-info';
+
+const mockImages = ['안녕하세요', '두번째', '내가 잃어버린 초코파이'];
+
+const InfoMock = {
+  title: '100만원',
+  timevalue: '9/23 15:00',
+  locationvalue: '3번째 소나무 5번째 뿌리',
+};
+
+const LostItemsInfo = () => {
+  return (
+    <>
+      <Carousel type="details">
+        {mockImages.map((imageUrl, index) => (
+          <img
+            key={index}
+            src={imageUrl}
+            alt={`분실물 이미지 ${index + 1}`}
+          />
+        ))}
+      </Carousel>
+      <DetailInfo
+        title={InfoMock.title}
+        time="습득시간"
+        timevalue={InfoMock.timevalue}
+        location="습득위치"
+        locationvalue={InfoMock.locationvalue}
+      />
+    </>
+  );
+};
+export default LostItemsInfo;

--- a/src/router/lazy.ts
+++ b/src/router/lazy.ts
@@ -11,6 +11,9 @@ export const ShowDetailPage = lazy(
 export const LandPage = lazy(() => import('@pages/land/land'));
 export const LoginPage = lazy(() => import('@pages/login/login'));
 export const LostItemsPage = lazy(() => import('@pages/lost-items/lost-items'));
+export const LostItemIngoPage = lazy(
+  () => import('@pages/lost-item-info/lost-item-info'),
+);
 export const TicketPage = lazy(() => import('@pages/ticket/ticket'));
 export const LoginFallbackPage = lazy(
   () => import('@pages/login-fallback/login-fallback'),

--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -7,6 +7,7 @@ export const routePath = {
   LAND: '/land',
   LOGIN: '/login',
   LOST_ITEMS: '/lost-items',
+  LOST_ITEM_INFO: '/lost-items/:id',
   TICKET: '/ticket',
   ADMIN_LOGIN: '/admin-login',
 } as const;

--- a/src/router/routes/global-routes.tsx
+++ b/src/router/routes/global-routes.tsx
@@ -9,6 +9,7 @@ import {
   TicketPage,
   LoginFallbackPage,
   AdminLoginPage,
+  LostItemIngoPage,
 } from '../lazy';
 import { routePath } from '../path';
 
@@ -25,6 +26,7 @@ export const publicRoutesOthers = [
   { path: routePath.LAND, Component: LandPage },
   { path: routePath.ADMIN_LOGIN, Component: AdminLoginPage },
   { path: routePath.SHOW_DETAIL, Component: ShowDetailPage },
+  { path: routePath.LOST_ITEM_INFO, Component: LostItemIngoPage },
 ];
 
 export const protectedRoutes = [


### PR DESCRIPTION
## 💬 Describe

> #96

해당 PR에 대해 설명해 주세요.
분실물 페이지에서 특정 분실물 카드 클릭시 이동되는 분실물 상세 정보 페이지입니다.

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.
- losts-item/:id 라우팅을 추가했습니다.
- `Carousel`이미지 컴포넌트, `DetailInfo`시간 위치 컴포넌트를 사용했습니다.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="389" height="614" alt="image" src="https://github.com/user-attachments/assets/aae852a0-a8f0-4f2b-a214-9aa2117b0fee" />

