### PR TITLE
Feat: 카카오 로그인 버튼 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 VITE_API_BASE_URL= 'API 기본 URL'
+VITE_KAKAO_LOGIN_URL= '카카오 로그인 url'
+VITE_KAKAO_LOCAL_REDIRECT_URI = '로컬 환경에서 카카오 로그인 리다이렉트 URI'
+VITE_KAKAO_PROD_REDIRECT_URI = '프로덕션 환경에서 카카오 로그인 리다이렉트 URI'

--- a/src/shared/components/kakao-login-button/kakao-login-button.css.ts
+++ b/src/shared/components/kakao-login-button/kakao-login-button.css.ts
@@ -1,0 +1,20 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@shared/styles';
+
+export const container = style({
+  display: 'flex',
+  width: '32.7rem',
+  height: '5.4rem',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '0.6rem',
+
+  borderRadius: '12px',
+  backgroundColor: themeVars.color.kakao_yellow,
+});
+
+export const text = style({
+  ...themeVars.fontStyles.button2_sb_16,
+  color: themeVars.color.gray_900,
+});

--- a/src/shared/components/kakao-login-button/kakao-login-button.tsx
+++ b/src/shared/components/kakao-login-button/kakao-login-button.tsx
@@ -1,0 +1,34 @@
+import { appConfig } from '@shared/configs/app-config';
+import { IcSvgKakaoTalk } from '@shared/icons';
+
+import * as styles from './kakao-login-button.css';
+
+const BUTTON_TEXT = '카카오 로그인';
+
+const KakaoLoginButton = () => {
+  const handleKakaoLogin = () => {
+    const redirectUri =
+      window.location.hostname === 'localhost'
+        ? appConfig.auth.kakaoLocalRedirectUrl
+        : appConfig.auth.kakaoProdRedirectUrl;
+
+    const loginUrl = `${appConfig.auth.kakaoLoginUrl}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+
+    window.location.href = loginUrl;
+  };
+
+  return (
+    <button
+      className={styles.container}
+      onClick={handleKakaoLogin}
+    >
+      <IcSvgKakaoTalk
+        width="3.2rem"
+        height="2.7rem"
+      />
+      <p className={styles.text}>{BUTTON_TEXT}</p>
+    </button>
+  );
+};
+
+export default KakaoLoginButton;


### PR DESCRIPTION
## 💬 Describe

> - #101 

해당 PR에 대해 설명해 주세요.
- 카카오 로그인 버튼 구현

## 📑 Task
기존 버튼 컴포넌트와 카카오 로그인 버튼을 구분한 이유는 카카오 로그인 버튼에서만 OAuth 관련 비즈니스 로직이 포함되기 때문이에요.

카카오 로그인 버튼을 누르면 로컬 또는 배포 redirectUri가 지정이 되고 `window.location.href = loginUrl;`을 통해 카카오 로그인 페이지로 이동하게 됩니다.

### redirectUrl은 왜 필요할까요??
로그인 이후 결과를 돌려줄 주소가 필요해요.
사용자가 카카오 로그인 페이지에서 인증을 마치면, 카카오 서버는 결과(code 또는 error)를 어딘가로 돌려줘야 해요. 그 “돌려줄 곳”이 바로 redirect_uri 입니다.

### redirectUrl이 왜 두개에요?
- 개발 환경: http://localhost:5173/auth/kakao/callback
- 운영 환경: https://passtival.com/auth/kakao/callback

(이 주소는 예시입니다. 가짜)
로컬에서 개발할 때랑 실제 서비스에서 동작할 때 주소가 다르니까 환경별 redirect_uri 설정이 필요해요


## 📸 Screenshot
<img width="352" height="60" alt="image" src="https://github.com/user-attachments/assets/8263779b-d41a-4e8d-8200-1b501bf43133" />
