### PR TITLE
Feature/boothdetailitem/#78

### DIFF
--- a/src/shared/components/booth-detail-item/booth-detail-item.css.ts
+++ b/src/shared/components/booth-detail-item/booth-detail-item.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@shared/styles';
+
+export const boothDetailItem = style({
+  display: 'flex',
+  width: '37.5rem',
+  height: '13.8rem',
+  padding: '1.9rem 3rem',
+  gap: '3.8rem',
+  wordBreak: 'keep-all',
+});
+
+export const boothText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'left',
+});
+
+export const boothItemName = style({
+  ...themeVars.fontStyles.title_b_20,
+});
+
+export const boothPrice = style({
+  ...themeVars.fontStyles.title_b_16,
+  color: themeVars.color.main_blue,
+});
+
+export const boothInfo = style({
+  display: 'inline-grid',
+  gap: '0.6rem 0',
+  ...themeVars.fontStyles.body1_r_15,
+  color: themeVars.color.gray_600,
+});
+
+export const boothImg = style({
+  display: 'flex',
+});

--- a/src/shared/components/booth-detail-item/booth-detail-item.tsx
+++ b/src/shared/components/booth-detail-item/booth-detail-item.tsx
@@ -1,13 +1,11 @@
-//import * as style from './booth-detail-item.css';
-
-//import React from "react";
+import * as style from './booth-detail-item.css';
 
 export type BoothCategory = 'menu' | 'experience';
 
 type BaseProps = {
   itemName: string;
   itemInfo?: string;
-  className?: string;
+  img: string;
 };
 
 type MenuProps = BaseProps & {
@@ -26,27 +24,29 @@ const formatPrice = (p: number | string) =>
   typeof p === 'number' ? p.toLocaleString('ko-KR') : p;
 
 export default function BoothDetailItem(props: BoothDetailItemProps) {
-  const { itemName, itemInfo, className } = props;
+  const { itemName, itemInfo, img } = props;
   const isMenu = props.category === 'menu';
 
   return (
     <article
-      className={className}
       aria-label="부스 상세 아이템"
+      className={style.boothDetailItem}
     >
-      <div className="booth-detail-item rounded-xl border bg-white p-5">
-        <h3 className="title text-2xl font-extrabold">{itemName}</h3>
+      <div className={style.boothText}>
+        <div className={style.boothItemName}>{itemName}</div>
 
         {isMenu && (
-          <div className="price mt-1 text-lg font-bold">
-            {formatPrice(props.price)} 원
-          </div>
+          <div className={style.boothPrice}>{formatPrice(props.price)} 원</div>
         )}
 
-        {itemInfo && (
-          <p className="info mt-2 text-slate-500 leading-relaxed">{itemInfo}</p>
-        )}
+        {itemInfo && <p className={style.boothInfo}>{itemInfo}</p>}
       </div>
+      <img
+        className={style.boothImg}
+        src={img}
+        width={100}
+        height={100}
+      />
     </article>
   );
 }

--- a/src/shared/components/booth-detail-item/booth-detail-item.tsx
+++ b/src/shared/components/booth-detail-item/booth-detail-item.tsx
@@ -1,10 +1,10 @@
 import * as style from './booth-detail-item.css';
 
-export type BoothCategory = 'menu' | 'experience';
+export type BoothCategory = 'menu' | 'active';
 
 type BaseProps = {
   itemName: string;
-  itemInfo?: string;
+  itemInfo: string;
   img: string;
 };
 
@@ -13,12 +13,12 @@ type MenuProps = BaseProps & {
   price: number | string;
 };
 
-type ExperienceProps = BaseProps & {
-  category: 'experience';
+type ActiveProps = BaseProps & {
+  category: 'active';
   price?: never;
 };
 
-export type BoothDetailItemProps = MenuProps | ExperienceProps;
+export type BoothDetailItemProps = MenuProps | ActiveProps;
 
 const formatPrice = (p: number | string) =>
   typeof p === 'number' ? p.toLocaleString('ko-KR') : p;
@@ -39,7 +39,7 @@ export default function BoothDetailItem(props: BoothDetailItemProps) {
           <div className={style.boothPrice}>{formatPrice(props.price)} 원</div>
         )}
 
-        {itemInfo && <p className={style.boothInfo}>{itemInfo}</p>}
+        <p className={style.boothInfo}>{itemInfo}</p>
       </div>
       <img
         className={style.boothImg}

--- a/src/shared/components/booth-detail-item/booth-detail-item.tsx
+++ b/src/shared/components/booth-detail-item/booth-detail-item.tsx
@@ -1,5 +1,52 @@
-import * as style from './booth-detail-item.css';
+//import * as style from './booth-detail-item.css';
 
-const BoothDetailItem = () => {};
+//import React from "react";
 
-export default BoothDetailItem;
+export type BoothCategory = 'menu' | 'experience';
+
+type BaseProps = {
+  itemName: string;
+  itemInfo?: string;
+  className?: string;
+};
+
+type MenuProps = BaseProps & {
+  category: 'menu';
+  price: number | string;
+};
+
+type ExperienceProps = BaseProps & {
+  category: 'experience';
+  price?: never;
+};
+
+export type BoothDetailItemProps = MenuProps | ExperienceProps;
+
+const formatPrice = (p: number | string) =>
+  typeof p === 'number' ? p.toLocaleString('ko-KR') : p;
+
+export default function BoothDetailItem(props: BoothDetailItemProps) {
+  const { itemName, itemInfo, className } = props;
+  const isMenu = props.category === 'menu';
+
+  return (
+    <article
+      className={className}
+      aria-label="부스 상세 아이템"
+    >
+      <div className="booth-detail-item rounded-xl border bg-white p-5">
+        <h3 className="title text-2xl font-extrabold">{itemName}</h3>
+
+        {isMenu && (
+          <div className="price mt-1 text-lg font-bold">
+            {formatPrice(props.price)} 원
+          </div>
+        )}
+
+        {itemInfo && (
+          <p className="info mt-2 text-slate-500 leading-relaxed">{itemInfo}</p>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/shared/components/booth-detail-item/booth-detail-item.tsx
+++ b/src/shared/components/booth-detail-item/booth-detail-item.tsx
@@ -1,0 +1,5 @@
+import * as style from './booth-detail-item.css';
+
+const BoothDetailItem = () => {};
+
+export default BoothDetailItem;

--- a/src/shared/components/booth-detail-item/booth-detail-item.tsx
+++ b/src/shared/components/booth-detail-item/booth-detail-item.tsx
@@ -5,7 +5,7 @@ export type BoothCategory = 'menu' | 'active';
 type BaseProps = {
   itemName: string;
   itemInfo: string;
-  img: string;
+  itemImg: string;
 };
 
 type MenuProps = BaseProps & {
@@ -24,7 +24,7 @@ const formatPrice = (p: number | string) =>
   typeof p === 'number' ? p.toLocaleString('ko-KR') : p;
 
 export default function BoothDetailItem(props: BoothDetailItemProps) {
-  const { itemName, itemInfo, img } = props;
+  const { itemName, itemInfo, itemImg } = props;
   const isMenu = props.category === 'menu';
 
   return (
@@ -43,7 +43,7 @@ export default function BoothDetailItem(props: BoothDetailItemProps) {
       </div>
       <img
         className={style.boothImg}
-        src={img}
+        src={itemImg}
         width={100}
         height={100}
       />


### PR DESCRIPTION
## 💬 Describe

> - #78 

메뉴 카테고리와 체험 활동 카테고리에 대한 각각의 item 을 담는 컴포넌트를 구현하였습니다.

1. `booth-detail-item.tsx` : 각 아이템에 대한 itemName, itemPrice(메뉴 카테고리에서만 랜더링), itemInfo, itemIcon을 props로 받아와서 관리합니다.
2. `booth-detail-item.css.ts` : booth-detail-item 컴포넌트에 적용할 css 파일입니다.

## 📑 Task


**div** 태그 대신 **article** 태그를 사용한 이유는 각 카드 자체만으로 의미가 완결되기 때문에 **div** 태그 대신 **article** 태그를 사용해 보았습니다.

```
type BaseProps = {
  itemName: string;
  itemInfo?: string;
  img: string;
};

type MenuProps = BaseProps & {
  category: 'menu';
  price: number | string;
};

type ActiveProps = BaseProps & {
  category: 'active';
  price?: never;
};

export type BoothDetailItemProps = MenuProps | ActiveProps;
```

현재 위치한 카테고리 (menu / active) 에 따라서 가격을 표시할지에 대한 여부를 결정하도록합니다. 만약 menu 일 경우 가격을 표시하게 되고, active 일 경우 가격 영역 자체를 랜더링하지 않게 하였습니다.



```
wordBreak: 'keep-all',
```
`booth-detail-item.css.ts` 에서 가독성을 높이기 위해 단어 중간에 줄바꿈을 허용하지 않도록 설정하였습니다. 


### 사용 형태
```
<BoothDetailItem
  category="menu"
  itemName="카레 우동"
  price={3000}
  itemInfo="갓 지은 돌볶음 취두부 곰팡이 팔지마세요"
  img={udonImg}
/>

<BoothDetailItem
  category="experience"
  itemName="도예 체험"
  itemInfo="물레 돌리기 20분 + 유약 고르기"
  img={udonImg}
/>
```

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot
<img width="379" height="353" alt="image" src="https://github.com/user-attachments/assets/9664ad8d-28af-41b6-9480-1f9d3b02f0c0" />
<img width="429" height="151" alt="image" src="https://github.com/user-attachments/assets/c3101c0e-8db8-4d92-bb50-472e3db4a555" />
