### PR TITLE
Feat: 홈 메인 페이지 구현

### DIFF
--- a/src/pages/home/home.css.ts
+++ b/src/pages/home/home.css.ts
@@ -1,0 +1,25 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const chipContainer = style({
+  display: 'flex',
+  gap: '4.1rem',
+  height: '4.7rem',
+  justifyContent: 'center',
+});
+
+export const noticeText = style({
+  width: '37.4rem',
+  height: '7rem',
+  padding: '1.3rem 2.4rem 1rem 2.4rem',
+});
+
+export const festivalScheduleText = style({
+  width: '100%',
+  height: '8rem',
+  padding: '2rem 23.2rem 1.8rem 2.4rem',
+});

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,4 +1,100 @@
+import { useState } from 'react';
+
+import Carousel from '@shared/components/carousel/carousel';
+import Chip from '@shared/components/chip/chip';
+import TimeTable from '@shared/components/timeTable/timeTable';
+import {
+  FESTIVAL_DAY,
+  FESTIVAL_PERIOD,
+  NOTICE,
+  TODAY_FESTIVAL_SCHEDULE,
+  TODAY_FESTIVAL_SCHEDULE_DETAIL,
+} from '@shared/constants/festivalSchedule';
+import { themeVars } from '@shared/styles';
+
+import * as styles from './home.css';
+
+const mokImages = ['아~~~', '나의 맥북님은...', '언제 오시나...'];
+
+const schedules = [
+  {
+    day: 1,
+    startIso: '2025-08-28T13:00:00',
+    endIso: '2025-08-28T14:00:00',
+    title: '공연 1',
+    assignee: '컴공',
+    description: '#즐겨보자',
+    imgSrc: '/images/sample1.png',
+    imgAlt: '공연 1 이미지',
+  },
+  {
+    day: 2,
+    startIso: '2025-08-28T15:00:00',
+    endIso: '2025-08-28T16:00:00',
+    title: '공연 2',
+    assignee: '디자인',
+    description: '#흥겨운 무대',
+    imgSrc: '/images/sample2.png',
+    imgAlt: '공연 2 이미지',
+  },
+  {
+    day: 3,
+    startIso: '2025-08-28T18:00:00',
+    endIso: '2025-08-28T19:30:00',
+    title: '공연 3',
+    assignee: '경영',
+    description: '#마지막날을_불태우자',
+    imgSrc: '/images/sample3.png',
+    imgAlt: '공연 3 이미지',
+  },
+];
+
 const Home = () => {
-  return <div>home</div>;
+  const [selectedDay, setSelectedDay] = useState(1);
+  return (
+    <div className={styles.container}>
+      <div></div>
+      <div className={styles.noticeText}>
+        <p style={themeVars.fontStyles.title_b_22}>{NOTICE}</p>
+        <p style={themeVars.fontStyles.button2_sb_12}>{FESTIVAL_PERIOD}</p>
+      </div>
+      <Carousel type="details">
+        {mokImages.map((imageUrl, index) => (
+          <img
+            key={index}
+            src={imageUrl}
+            alt={`분실물 이미지 ${index + 1}`}
+          />
+        ))}
+      </Carousel>
+      <div className={styles.festivalScheduleText}>
+        <p style={themeVars.fontStyles.title_b_18}>{TODAY_FESTIVAL_SCHEDULE}</p>
+        <p style={themeVars.fontStyles.button2_sb_12}>
+          {TODAY_FESTIVAL_SCHEDULE_DETAIL}
+        </p>
+      </div>
+      <div className={styles.chipContainer}>
+        {FESTIVAL_DAY.map((dayLabel, idx) => {
+          const dayNumber = idx + 1;
+          return (
+            <Chip
+              key={dayNumber}
+              label={dayLabel}
+              selected={selectedDay === dayNumber}
+              onChange={() => setSelectedDay(dayNumber)}
+            />
+          );
+        })}
+      </div>
+      {schedules
+        .filter((schedule) => schedule.day === selectedDay)
+        .map((schedule, idx) => (
+          <TimeTable
+            key={idx}
+            {...schedule}
+          />
+        ))}
+    </div>
+  );
 };
 export default Home;

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -3,13 +3,7 @@ import { useState } from 'react';
 import Carousel from '@shared/components/carousel/carousel';
 import Chip from '@shared/components/chip/chip';
 import TimeTable from '@shared/components/timeTable/timeTable';
-import {
-  FESTIVAL_DAY,
-  FESTIVAL_PERIOD,
-  NOTICE,
-  TODAY_FESTIVAL_SCHEDULE,
-  TODAY_FESTIVAL_SCHEDULE_DETAIL,
-} from '@shared/constants/festivalSchedule';
+import { HOME_TEXT } from '@shared/constants/festivalSchedule';
 import { themeVars } from '@shared/styles';
 
 import * as styles from './home.css';
@@ -55,8 +49,10 @@ const Home = () => {
     <div className={styles.container}>
       <div></div>
       <div className={styles.noticeText}>
-        <p style={themeVars.fontStyles.title_b_22}>{NOTICE}</p>
-        <p style={themeVars.fontStyles.button2_sb_12}>{FESTIVAL_PERIOD}</p>
+        <p style={themeVars.fontStyles.title_b_22}>{HOME_TEXT.NOTICE}</p>
+        <p style={themeVars.fontStyles.button2_sb_12}>
+          {HOME_TEXT.FESTIVAL_PERIOD}
+        </p>
       </div>
       <Carousel type="details">
         {mokImages.map((imageUrl, index) => (
@@ -68,13 +64,15 @@ const Home = () => {
         ))}
       </Carousel>
       <div className={styles.festivalScheduleText}>
-        <p style={themeVars.fontStyles.title_b_18}>{TODAY_FESTIVAL_SCHEDULE}</p>
+        <p style={themeVars.fontStyles.title_b_18}>
+          {HOME_TEXT.TODAY_FESTIVAL_SCHEDULE}
+        </p>
         <p style={themeVars.fontStyles.button2_sb_12}>
-          {TODAY_FESTIVAL_SCHEDULE_DETAIL}
+          {HOME_TEXT.TODAY_FESTIVAL_SCHEDULE_DETAIL}
         </p>
       </div>
       <div className={styles.chipContainer}>
-        {FESTIVAL_DAY.map((dayLabel, idx) => {
+        {HOME_TEXT.FESTIVAL_DAY.map((dayLabel, idx) => {
           const dayNumber = idx + 1;
           return (
             <Chip

--- a/src/shared/constants/festivalSchedule.ts
+++ b/src/shared/constants/festivalSchedule.ts
@@ -1,6 +1,8 @@
 export const OPENING_HOURS = '운영시간';
-export const NOTICE = '공지사항';
-export const FESTIVAL_PERIOD = '축제 기간 (9/23 ~ 9/25)';
-export const TODAY_FESTIVAL_SCHEDULE = '오늘의 축제 일정';
-export const TODAY_FESTIVAL_SCHEDULE_DETAIL = '금일의 축제 정보입니다.';
-export const FESTIVAL_DAY = ['1일차', '2일차', '3일차'];
+export const HOME_TEXT = {
+  NOTICE: '공지사항',
+  FESTIVAL_PERIOD: '축제 기간 (9/23 ~ 9/25)',
+  TODAY_FESTIVAL_SCHEDULE: '오늘의 축제 일정',
+  TODAY_FESTIVAL_SCHEDULE_DETAIL: '금일의 축제 정보입니다.',
+  FESTIVAL_DAY: ['1일차', '2일차', '3일차'],
+};

--- a/src/shared/constants/festivalSchedule.ts
+++ b/src/shared/constants/festivalSchedule.ts
@@ -1,1 +1,6 @@
 export const OPENING_HOURS = '운영시간';
+export const NOTICE = '공지사항';
+export const FESTIVAL_PERIOD = '축제 기간 (9/23 ~ 9/25)';
+export const TODAY_FESTIVAL_SCHEDULE = '오늘의 축제 일정';
+export const TODAY_FESTIVAL_SCHEDULE_DETAIL = '금일의 축제 정보입니다.';
+export const FESTIVAL_DAY = ['1일차', '2일차', '3일차'];


### PR DESCRIPTION
## 💬 Describe

> - #74 

홈 메인 페이지를 구현하였습니다. 
맨 상단 탭은 디자인 나오는대로 추가하겠습니다.

## 📑 Task
홈 메인 페이지에 있는 텍스트 상수화 했습니다.
``Carousel``, ``Chip``, ``TimeTable`` 를 ``map``을 통해 렌더링 했습니다.
TimeTable은 Chip 상태에 따라 조건부 렌더링을 설정하였습니다.
```ts
      {schedules
        .filter((schedule) => schedule.day === selectedDay)
        .map((schedule, idx) => (
          <TimeTable
            key={idx}
            {...schedule}
          />
        ))}
```


## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
text부분을 컴포넌트로 만들까요? 부스랑 홈 메인페이지에서 밖에 안쓰고 그마저도 살짝식 달라서 일부러 컴포넌트화 안했는데 조금 코드가 지저분한거 같아서요 

## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="482" height="760" alt="image" src="https://github.com/user-attachments/assets/f6a5d4f2-3e1b-4368-9df8-c4fb06d9d3bb" />
