### PR TITLE
fix: Tab 컴포넌트 반응형 고려

### DIFF
--- a/src/shared/components/tab/tab.css.ts
+++ b/src/shared/components/tab/tab.css.ts
@@ -5,7 +5,7 @@ import { themeVars } from '@shared/styles';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(0, 1fr))',
   width: '100%',
 });
 

--- a/src/shared/components/tab/tab.css.ts
+++ b/src/shared/components/tab/tab.css.ts
@@ -3,9 +3,14 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { themeVars } from '@shared/styles';
 
+export const container = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  width: '100%',
+});
+
 export const buttonVariants = recipe({
   base: {
-    width: '12.5rem ',
     height: '5rem',
 
     backgroundColor: themeVars.color.gray_200,
@@ -26,5 +31,3 @@ export const buttonVariants = recipe({
     },
   },
 });
-
-export const tablist = style({});

--- a/src/shared/components/tab/tab.tsx
+++ b/src/shared/components/tab/tab.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 
 import { useTabsContext, TabsContext } from './hooks/use-tabs-context';
 import * as styles from './tab.css';
-import { buttonVariants } from './tab.css';
 
 interface TabContainerProps {
   children: ReactNode;
@@ -40,7 +39,7 @@ const List = ({ children }: TabListProps) => {
   return (
     <div
       role="tablist"
-      className={styles.tablist}
+      className={styles.container}
     >
       {children}
     </div>
@@ -56,7 +55,7 @@ const Item = ({ children, value }: TabItemProps) => {
       role="tab"
       aria-selected={isActive}
       onClick={() => setSelectedTab(value)}
-      className={buttonVariants({ selected: isActive })}
+      className={styles.buttonVariants({ selected: isActive })}
     >
       {children}
     </button>


### PR DESCRIPTION
## 💬 Describe

> - #110 

해당 PR에 대해 설명해 주세요.

## 📑 Task
기존 Tab 컴포넌트가 아이폰SE(width: 375px) 사이즈에 딱 맞게 구현 되어있어 다른 기종으로 보았을 때 너비가 맞지 않는 문제가 발생하였습니다. 그래서 Tab.List에 `display: grid`를 적용하여 가로 사이즈를 조절하였습니다.

처음에는 `gridTemplateColumns: 'repeat(3, 1fr)'` 이와 같이 Tab의 요소가 3개이니 3개일때만을 고려하여 코드를 수정하였습니다.
하지만 추후 Tab.Item의 개수가 추가될 수 가능성이 있지 않을까 라는 생각이 들게 되었고 `gridTemplateColumns: 'repeat(auto-fit, minmax(0, 1fr))'`을 사용하여 개수에 상관 없이 너비가 자동으로 맞춰지도록 수정하였습니다. 


## 📸 Screenshot
## Before
<img width="200" height="500" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/5ec1b636-06fe-4648-bc52-0c8e25dfefc0" />

## After
<img width="200" height="500" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/ca573811-1b49-4595-b6f2-df9cf3f56ebb" />
<img width="200" height="500" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/40222e09-4737-477e-90b5-a6866985a7d8" />
<img width="200" height="500" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/1d259333-5061-46d3-9521-5a355e438857" />
