### PR TITLE
Feat/blind match completed/#125

### DIFF
--- a/src/pages/blind-match/components/completed/completed.css.ts
+++ b/src/pages/blind-match/components/completed/completed.css.ts
@@ -1,0 +1,45 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@shared/styles';
+
+export const title = style({
+  height: '7.3rem',
+  padding: '1.3rem 2.4rem 0 2.4rem',
+});
+export const container = style({
+  display: 'grid',
+  placeItems: 'center',
+});
+export const completedContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '14.5rem 0 15rem 0',
+});
+export const endContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '14.5rem 0 16.5rem 0',
+});
+
+export const message = style({
+  ...themeVars.fontStyles.title_b_16,
+  color: themeVars.color.main_blue,
+});
+export const time = style({
+  ...themeVars.fontStyles.body1_r_15,
+  color: themeVars.color.gray_900,
+});
+export const caution = style({
+  ...themeVars.fontStyles.caption2_m_12,
+  color: themeVars.color.gray_900,
+});
+export const notice = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.3rem',
+  paddingTop: '0.6rem',
+  ...themeVars.fontStyles.button_r_12,
+  color: themeVars.color.gray_900,
+});

--- a/src/pages/blind-match/components/completed/completed.tsx
+++ b/src/pages/blind-match/components/completed/completed.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+
+import Button from '@shared/components/button/button';
+import Title from '@shared/components/title/title';
+import { IcSvgCaution } from '@shared/icons';
+
+import * as styles from './completed.css';
+
+const Completed = () => {
+  const [isMatchingEnd, setIsMatchingEnd] = useState<boolean>(false);
+
+  useEffect(() => {
+    const checkMatchingStatus = () => {
+      const now = new Date();
+      const endTime = new Date();
+      endTime.setHours(13, 51, 0, 0);
+
+      if (now > endTime) {
+        setIsMatchingEnd(true);
+      }
+    };
+
+    checkMatchingStatus();
+
+    const intervalId = setInterval(checkMatchingStatus, 60000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <>
+      <div className={styles.title}>
+        <Title
+          mainTitle="번호팅"
+          subTitle="랜덤 매칭으로 새로운 인연을 만들어주는 서비스"
+        />
+      </div>
+      <div className={styles.container}>
+        {isMatchingEnd ? (
+          <>
+            <div className={styles.endContainer}>
+              <p className={styles.message}>
+                1일차 매칭 신청이 마감되었습니다.
+              </p>
+              <p className={styles.time}>[신청 가능 시간: 00:00 ~ 17:30]</p>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={styles.completedContainer}>
+              <p className={styles.message}>
+                1일차 매칭 신청이 완료되었습니다.
+              </p>
+              <p className={styles.time}>[신청 가능 시간: 00:00 ~ 17:30]</p>
+              <p className={styles.caution}>
+                ※ 성비 불균형으로 인해 매칭이 이루어지지 않을 수 있습니다.
+              </p>
+            </div>
+          </>
+        )}
+
+        <Button
+          disabled={true}
+          onClick={() => {}}
+        >
+          매칭 결과 대기중
+        </Button>
+        <div className={styles.notice}>
+          <IcSvgCaution style={{ width: 12, height: 12 }} />
+          <p>18시에 매칭결과가 제공됩니다.</p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Completed;

--- a/src/pages/blind-match/components/completed/completed.tsx
+++ b/src/pages/blind-match/components/completed/completed.tsx
@@ -13,7 +13,7 @@ const Completed = () => {
     const checkMatchingStatus = () => {
       const now = new Date();
       const endTime = new Date();
-      endTime.setHours(13, 51, 0, 0);
+      endTime.setHours(17, 30, 0, 0);
 
       if (now > endTime) {
         setIsMatchingEnd(true);


### PR DESCRIPTION
## 💬 Describe

> - #125

해당 PR에 대해 설명해 주세요.
- 사용자의 현재 시각을 기준으로 매칭 신청 가능 상태와 마감 상태를 분리하여 동적으로 UI가 변경되도록 처리했습니다.
- useEffect 훅을 사용하여 현재 시간이 매칭 마감 시간(17:30)을 지났는지 확인하고, 1분마다 상태를 업데이트하도록 `setInterval`을 적용했습니다. (현재 시간보다 이전 시간으로 제한을 두면 마감 페이지가 보입니다"
- {isMatchingEnd ? }조건부 렌더링으로 `isMatchingEnd` 참/거짓에 따라 화면 내용을 유연하게 바꿀 수 있습니다.

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.
- useState 훅을 사용하여 `isMatchingEnd` 상태를 관리합니다. 이 상태가 `true`일 경우 마감 화면을, `false`일 경우 신청 완료 화면을 렌더링합니다.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
++마감 페이지 notice 멘트 수정하겠슨다... ++ 일차도 탭에서 받아오는 것은 잠시,,,, 월요일에 수정하겠습니다.

## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="383" height="674" alt="image" src="https://github.com/user-attachments/assets/9d710f8a-9c29-4694-b30f-6de01198359a" />

<img width="384" height="676" alt="image" src="https://github.com/user-attachments/assets/a6ac91c4-70a1-47ae-ba91-dfc94853aeb9" />
