### PR TITLE
Refactor: 응모 페이지 카카오 로그인 라우터 설정

### DIFF
--- a/src/router/routes/protected-route.tsx
+++ b/src/router/routes/protected-route.tsx
@@ -11,7 +11,10 @@ export function ProtectedRoute() {
   if (!isAuthenticated) {
     const currentPath = location.pathname;
 
-    if (currentPath === routePath.BLIND_MATCH) {
+    if (
+      currentPath === routePath.BLIND_MATCH ||
+      currentPath === routePath.TICKET
+    ) {
       return (
         <Navigate
           to={routePath.LOGIN}


### PR DESCRIPTION
## 💬 Describe

> - #175 

- 응모권 페이지도 카카오 로그인 후 사용되도록 설정

## 📑 Task
현재 피그마 수정 전에 번호팅 페이지에서만 카카오 로그인을 사용했지만 응모권 페이지 또한 카카오 로그인이 필요해짐에 따라 라우터 설정을 하였습니다. 현재
```tsx
currentPath === routePath.BLIND_MATCH ||
currentPath === routePath.TICKET
```
이렇게 두개만 설정해 두었고, TicketOnboarding 페이지는 라우터 설정을 하지 않은 이유는
`const hasTicketOnboardingToken = !!tokenService.getTicketOnboardingToken();` 여기서 이미 ticket페이지로 이동하여도 티켓온보딩 토큰이 없으면 ticketOnboarding페이지로 이동하는 로직이 구현되어있기 때문입니다.


## 📸 Screenshot

https://github.com/user-attachments/assets/4f80db1f-63bd-4e9a-a86a-dc34acc45490

