### PR TITLE
Feat: 부스 전체 조회 api 연동

### DIFF
--- a/src/pages/booth/apis/queries.ts
+++ b/src/pages/booth/apis/queries.ts
@@ -1,0 +1,31 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { END_POINT } from '@shared/apis/config/end-point';
+import { api } from '@shared/apis/config/instance';
+import { BOOTH_QUERY_KEY } from '@shared/apis/keys/query-key';
+
+import type { BoothCursorApiResponse } from '../types/types';
+
+export const getBoothsCursor = async (
+  cursor?: number,
+  size?: number,
+): Promise<BoothCursorApiResponse> => {
+  const { data } = await api.get<BoothCursorApiResponse>(
+    END_POINT.BOOTHS_CURSOR,
+    {
+      params: {
+        cursor,
+        size,
+      },
+    },
+  );
+  return data;
+};
+
+export const BOOTH_QUERY_OPTIONS = {
+  BOOTHS_CURSOR: (cursor?: number, size?: number) =>
+    queryOptions({
+      queryKey: BOOTH_QUERY_KEY.BOOTHS_CURSOR(cursor, size),
+      queryFn: () => getBoothsCursor(cursor, size),
+    }),
+} as const;

--- a/src/pages/booth/booth.css.ts
+++ b/src/pages/booth/booth.css.ts
@@ -23,3 +23,10 @@ export const boothinfoText = style({
 export const carouselWrapper = style({
   padding: '0 2.4rem',
 });
+
+export const cardContainer = style({
+  padding: '0 2.4rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2rem',
+});

--- a/src/pages/booth/booth.tsx
+++ b/src/pages/booth/booth.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import Card from '@shared/components/card/card';
 import Carousel from '@shared/components/carousel/carousel';
 import Chip from '@shared/components/chip/chip';
 import Header from '@shared/components/header/header';
-import TimeTable from '@shared/components/timeTable/timeTable';
 import Title from '@shared/components/title/title';
 
 import * as styles from './booth.css';
@@ -25,8 +25,6 @@ const MOCK_BOOTH_DATA = [
   {
     id: 1,
     boothType: '학내부스',
-    startIso: '2025-08-28T13:00:00',
-    endIso: '2025-08-28T14:00:00',
     title: '공연 1',
     assignee: '컴공',
     description: '#즐겨보자',
@@ -36,8 +34,6 @@ const MOCK_BOOTH_DATA = [
   {
     id: 2,
     boothType: '체험',
-    startIso: '2025-08-28T15:00:00',
-    endIso: '2025-08-28T16:00:00',
     title: '공연 2',
     assignee: '디자인',
     description: '#흥겨운 무대',
@@ -47,8 +43,6 @@ const MOCK_BOOTH_DATA = [
   {
     id: 3,
     boothType: '푸드존',
-    startIso: '2025-08-28T18:00:00',
-    endIso: '2025-08-28T19:30:00',
     title: '공연 3',
     assignee: '경영',
     description: '#마지막날을_불태우자',
@@ -58,8 +52,6 @@ const MOCK_BOOTH_DATA = [
   {
     id: 4,
     boothType: '푸드존',
-    startIso: '2025-08-28T18:00:00',
-    endIso: '2025-08-28T19:30:00',
     title: '공연 3',
     assignee: '경영',
     description: '#마지막날을_불태우자',
@@ -69,8 +61,6 @@ const MOCK_BOOTH_DATA = [
   {
     id: 5,
     boothType: '푸드존',
-    startIso: '2025-08-28T18:00:00',
-    endIso: '2025-08-28T19:30:00',
     title: '공연 3',
     assignee: '경영',
     description: '#마지막날을_불태우자',
@@ -125,24 +115,13 @@ const Booth = () => {
           />
         ))}
       </div>
-
-      {MOCK_BOOTH_DATA.filter((schedule) =>
-        selectedType === '전체' ? true : schedule.boothType === selectedType,
-      ).map(
-        ({
-          id,
-          startIso,
-          endIso,
-          title,
-          assignee,
-          description,
-          imgSrc,
-          imgAlt,
-        }) => (
-          <TimeTable
+      <div className={styles.cardContainer}>
+        {MOCK_BOOTH_DATA.filter((schedule) =>
+          selectedType === '전체' ? true : schedule.boothType === selectedType,
+        ).map(({ id, title, assignee, description, imgSrc, imgAlt }) => (
+          <Card
+            type="lg"
             key={id}
-            startIso={startIso}
-            endIso={endIso}
             title={title}
             assignee={assignee}
             description={description}
@@ -150,8 +129,8 @@ const Booth = () => {
             imgAlt={imgAlt}
             onClick={() => handleClick(id)}
           />
-        ),
-      )}
+        ))}
+      </div>
     </>
   );
 };

--- a/src/pages/booth/booth.tsx
+++ b/src/pages/booth/booth.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
-import Card from '@shared/components/card/card';
+import BoothList from '@pages/booth/components/booth-list';
+
 import Carousel from '@shared/components/carousel/carousel';
 import Chip from '@shared/components/chip/chip';
 import Header from '@shared/components/header/header';
@@ -21,62 +21,8 @@ const mokImages = [
   'https://placehold.co/600x400',
 ];
 
-const MOCK_BOOTH_DATA = [
-  {
-    id: 1,
-    boothType: '학내부스',
-    title: '공연 1',
-    assignee: '컴공',
-    description: '#즐겨보자',
-    imgSrc: 'https://placehold.co/600x400',
-    imgAlt: '공연 1 이미지',
-  },
-  {
-    id: 2,
-    boothType: '체험',
-    title: '공연 2',
-    assignee: '디자인',
-    description: '#흥겨운 무대',
-    imgSrc: 'https://placehold.co/600x400',
-    imgAlt: '공연 2 이미지',
-  },
-  {
-    id: 3,
-    boothType: '푸드존',
-    title: '공연 3',
-    assignee: '경영',
-    description: '#마지막날을_불태우자',
-    imgSrc: 'https://placehold.co/600x400',
-    imgAlt: '공연 3 이미지',
-  },
-  {
-    id: 4,
-    boothType: '푸드존',
-    title: '공연 3',
-    assignee: '경영',
-    description: '#마지막날을_불태우자',
-    imgSrc: 'https://placehold.co/600x400',
-    imgAlt: '공연 3 이미지',
-  },
-  {
-    id: 5,
-    boothType: '푸드존',
-    title: '공연 3',
-    assignee: '경영',
-    description: '#마지막날을_불태우자',
-    imgSrc: 'https://placehold.co/600x400',
-    imgAlt: '공연 3 이미지',
-  },
-];
-
 const Booth = () => {
   const [selectedType, setSelectedType] = useState(BOOTH_TYPES[0]);
-
-  const navigate = useNavigate();
-
-  const handleClick = (id: number) => {
-    navigate(`/booth-detail/${id}`);
-  };
 
   return (
     <>
@@ -116,20 +62,7 @@ const Booth = () => {
         ))}
       </div>
       <div className={styles.cardContainer}>
-        {MOCK_BOOTH_DATA.filter((schedule) =>
-          selectedType === '전체' ? true : schedule.boothType === selectedType,
-        ).map(({ id, title, assignee, description, imgSrc, imgAlt }) => (
-          <Card
-            type="lg"
-            key={id}
-            title={title}
-            assignee={assignee}
-            description={description}
-            imgSrc={imgSrc}
-            imgAlt={imgAlt}
-            onClick={() => handleClick(id)}
-          />
-        ))}
+        <BoothList selectedType={selectedType} />
       </div>
     </>
   );

--- a/src/pages/booth/components/booth-list.tsx
+++ b/src/pages/booth/components/booth-list.tsx
@@ -1,0 +1,85 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import Card from '@shared/components/card/card';
+import ErrorMessage from '@shared/components/error-message/error-message';
+import Loading from '@shared/components/loading/loading';
+import { useIntersectionObserver } from '@shared/hooks/use-intersection-observer';
+
+import { getBoothsCursor } from '../apis/queries';
+
+interface BoothListProps {
+  selectedType: string;
+}
+
+const BoothList = ({ selectedType }: BoothListProps) => {
+  const navigate = useNavigate();
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useInfiniteQuery({
+    queryKey: ['booth', 'cursor'],
+    queryFn: ({ pageParam }) => getBoothsCursor(pageParam, 10),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage?.result?.nextCursor,
+    throwOnError: false,
+  });
+
+  const intersectionRef = useIntersectionObserver(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, hasNextPage && !isFetchingNextPage);
+
+  const handleClick = (id: number) => {
+    navigate(`/booth-detail/${id}`);
+  };
+  if (isLoading) {
+    return (
+      <Loading
+        size="medium"
+        message="부스 정보를 불러오는 중..."
+      />
+    );
+  }
+
+  if (error) {
+    return <ErrorMessage message="부스 정보를 불러올 수 없습니다." />;
+  }
+
+  return (
+    <>
+      {data?.pages
+        .flatMap((page) => page?.result?.content || [])
+        .filter((booth) =>
+          selectedType === '전체' ? true : booth?.type === selectedType,
+        )
+        .map((booth) => (
+          <Card
+            type="lg"
+            key={booth.id}
+            title={booth.name}
+            assignee={booth.department}
+            description={booth.info}
+            imgSrc={booth.imagePath}
+            imgAlt={`${booth.name} 이미지`}
+            onClick={() => handleClick(booth.id)}
+          />
+        ))}
+      {hasNextPage && (
+        <div
+          ref={intersectionRef}
+          style={{ height: '1px' }}
+        />
+      )}
+      {isFetchingNextPage && <div>더 많은 부스를 불러오는 중...</div>}
+    </>
+  );
+};
+
+export default BoothList;

--- a/src/pages/booth/types/types.ts
+++ b/src/pages/booth/types/types.ts
@@ -1,0 +1,23 @@
+import type { paths } from '@shared/apis/types/schema';
+
+export type BoothCursorResponse =
+  paths['/api/festival/booths/cursor']['get']['responses']['200']['content']['*/*'];
+
+export interface BoothCursorResult {
+  content: Array<{
+    id: number;
+    name: string;
+    type: string;
+    department: string;
+    info: string;
+    imagePath: string;
+  }>;
+  nextCursor?: number;
+}
+
+export interface BoothCursorApiResponse {
+  isSuccess: boolean;
+  code: number;
+  message: string;
+  result: BoothCursorResult;
+}

--- a/src/pages/lost-items/apis/queries.ts
+++ b/src/pages/lost-items/apis/queries.ts
@@ -11,6 +11,7 @@ export const COMMUNITY_QUERY_OPTIONS = {
     return queryOptions({
       queryKey: LOST_ITEM_QUERY_KEY.LOST_ITEM_PREVIEW(),
       queryFn: getLostItemList,
+      throwOnError: false,
     });
   },
 };

--- a/src/pages/lost-items/lost-items.tsx
+++ b/src/pages/lost-items/lost-items.tsx
@@ -8,6 +8,8 @@ import { COMMUNITY_QUERY_OPTIONS } from '@pages/lost-items/apis/queries';
 import { tokenService } from '@shared/auth/services/token-service';
 import Button from '@shared/components/button/button';
 import Card from '@shared/components/card/card';
+import ErrorMessage from '@shared/components/error-message/error-message';
+import Loading from '@shared/components/loading/loading';
 import { themeVars } from '@shared/styles';
 
 import { LOST_ITEMS } from './constants/lostItems';
@@ -15,7 +17,9 @@ import * as styles from './lost-items.css';
 
 const LostItems = () => {
   const navigate = useNavigate();
-  const { data } = useQuery(COMMUNITY_QUERY_OPTIONS.LOST_ITEMS_LIST());
+  const { data, error, isLoading } = useQuery(
+    COMMUNITY_QUERY_OPTIONS.LOST_ITEMS_LIST(),
+  );
 
   const isAdmin = !!tokenService.getAdminAccessToken();
 
@@ -48,16 +52,25 @@ const LostItems = () => {
         )}
       </div>
       <div className={styles.cardlist}>
-        {data?.result?.map(({ id, title, area, imagePath }) => (
-          <Card
-            key={id}
-            type="lg"
-            imgSrc={imagePath}
-            title={title}
-            description={area}
-            onClick={() => handleCardClick(id!)}
+        {isLoading ? (
+          <Loading
+            size="medium"
+            message="분실물 정보를 불러오는 중..."
           />
-        ))}
+        ) : error ? (
+          <ErrorMessage message="분실물 정보를 불러올 수 없습니다." />
+        ) : (
+          data?.result?.map(({ id, title, area, imagePath }) => (
+            <Card
+              key={id}
+              type="lg"
+              imgSrc={imagePath}
+              title={title}
+              description={area}
+              onClick={() => handleCardClick(id!)}
+            />
+          ))
+        )}
       </div>
     </>
   );

--- a/src/shared/apis/config/end-point.ts
+++ b/src/shared/apis/config/end-point.ts
@@ -11,4 +11,5 @@ export const END_POINT = {
   MEMBER_LEVEL_UP: '/api/member/level-up',
   ADMIN_RAFFLE_DAY: '/api/admin/raffle/{day}',
   ADMIN_RAFFLE_WINNERS: '/api/admin/raffle/{day}',
+  BOOTHS_CURSOR: '/api/festival/booths/cursor',
 } as const;

--- a/src/shared/apis/keys/query-key.ts
+++ b/src/shared/apis/keys/query-key.ts
@@ -24,6 +24,12 @@ export const RAFFLE_QUERY_KEY = {
 
 export const BOOTH_QUERY_KEY = {
   ALL: ['booth'],
+  BOOTHS_CURSOR: (cursor?: number, size?: number) => [
+    ...BOOTH_QUERY_KEY.ALL,
+    'cursor',
+    cursor,
+    size,
+  ],
 } as const;
 
 export const MATCHING_QUERY_KEY = {

--- a/src/shared/apis/types/schema.d.ts
+++ b/src/shared/apis/types/schema.d.ts
@@ -435,7 +435,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/raffle/prizes/{prizeId}': {
+  '/api/raffle/prizes/{days}': {
     parameters: {
       query?: never;
       header?: never;
@@ -444,7 +444,7 @@ export interface paths {
     };
     /**
      * 상품 조회
-     * @description 상품 ID로 특정 상품의 정보를 조회합니다.
+     * @description 날짜를 통해 특정 상품의 정보를 조회합니다.
      */
     get: operations['getPrizeById'];
     put?: never;
@@ -885,13 +885,6 @@ export interface components {
       prizeImagePath?: string;
       prizeName?: string;
     };
-    BaseResponsePrizeResponse: {
-      isSuccess?: boolean;
-      /** Format: int32 */
-      code?: number;
-      message?: string;
-      result?: components['schemas']['PrizeResponse'];
-    };
     BaseResponseMemberRaffleProfileResponse: {
       isSuccess?: boolean;
       /** Format: int32 */
@@ -1150,11 +1143,11 @@ export interface components {
       hosts?: string[];
       redirectView?: boolean;
       propagateQueryProperties?: boolean;
-      attributes?: {
-        [key: string]: string;
-      };
       attributesMap?: {
         [key: string]: unknown;
+      };
+      attributes?: {
+        [key: string]: string;
       };
       attributesCSV?: string;
     };
@@ -1180,8 +1173,8 @@ export interface components {
       majorVersion?: number;
       /** Format: int32 */
       minorVersion?: number;
-      attributeNames?: unknown;
       contextPath?: string;
+      attributeNames?: unknown;
       initParameterNames?: unknown;
       sessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
       /** Format: int32 */
@@ -2000,10 +1993,10 @@ export interface operations {
       header?: never;
       path: {
         /**
-         * @description 조회할 상품의 ID
+         * @description 조회할 상품의 날짜 / 프리미엄의 경우 4
          * @example 1
          */
-        prizeId: number;
+        days: number;
       };
       cookie?: never;
     };
@@ -2015,7 +2008,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          '*/*': components['schemas']['BaseResponsePrizeResponse'];
+          '*/*': components['schemas']['BaseResponseListPrizeResponse'];
         };
       };
     };

--- a/src/shared/components/card/card.css.ts
+++ b/src/shared/components/card/card.css.ts
@@ -13,8 +13,6 @@ export const container = recipe({
     width: '100%',
     height: '13.3rem',
     backgroundColor: themeVars.color.gray_500_40,
-
-    marginLeft: '0.8rem',
   },
 
   variants: {

--- a/src/shared/components/error-message/error-message.css.ts
+++ b/src/shared/components/error-message/error-message.css.ts
@@ -1,0 +1,10 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@shared/styles';
+
+export const container = style({
+  textAlign: 'center',
+  padding: '2rem',
+  ...themeVars.fontStyles.body1_r_15,
+  color: themeVars.color.gray_600,
+});

--- a/src/shared/components/error-message/error-message.tsx
+++ b/src/shared/components/error-message/error-message.tsx
@@ -1,0 +1,20 @@
+import * as styles from './error-message.css';
+
+interface ErrorMessageProps {
+  message?: string;
+  subMessage?: string;
+}
+
+const ErrorMessage = ({
+  message = '정보를 불러올 수 없습니다.',
+  subMessage = '잠시 후 다시 시도해주세요.',
+}: ErrorMessageProps) => {
+  return (
+    <div className={styles.container}>
+      <p>{message}</p>
+      <p>{subMessage}</p>
+    </div>
+  );
+};
+
+export default ErrorMessage;

--- a/src/shared/components/timeTable/timeTable.css.ts
+++ b/src/shared/components/timeTable/timeTable.css.ts
@@ -28,6 +28,12 @@ export const bottom = style({
   width: '100%',
   height: '14.5rem',
   borderLeft: `1px solid ${themeVars.color.main_yellow}`,
+  gap: '0.8rem',
+});
+
+export const leftBar = style({
+  height: '100%',
+  borderRadius: `1px solid ${themeVars.color.main_yellow}`,
 });
 
 export const text = style({

--- a/src/shared/components/timeTable/timeTable.tsx
+++ b/src/shared/components/timeTable/timeTable.tsx
@@ -42,6 +42,7 @@ const TimeTable = ({
         </p>
       </div>
       <div className={styles.bottom}>
+        <div className={styles.leftBar} />
         <Card
           title={title}
           assignee={assignee}

--- a/src/shared/hooks/use-intersection-observer.ts
+++ b/src/shared/hooks/use-intersection-observer.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+
+export const useIntersectionObserver = (
+  onIntersect: () => void,
+  enabled?: boolean,
+) => {
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !enabled) {
+        return;
+      }
+
+      const observer = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          onIntersect();
+        }
+      });
+
+      observer.observe(node);
+
+      return () => observer.disconnect();
+    },
+    [onIntersect, enabled],
+  );
+};


### PR DESCRIPTION
## 💬 Describe

> - #182 

해당 PR에 대해 설명해 주세요.
- 부스 전체 조회 커서 기반 페이지 네이션 api 연동
- TimeTable컴포넌트를 Card컴포넌트로 대체
- 부스 List 컴포넌트 분리
- 에러 바운더리 범위 축소

## 📑 Task
부스 페이지에서 TimeTable 대신 Card 컴포넌트를 사용하도록 수정했습니다. 기존 TimeTable의 왼쪽 막대기 UI가 디자인과 맞지 않아 스타일 수정하였습니다. 또한 부스 조회 로직이 흩어져 있어 가독성이 떨어져 BoothList 컴포넌트를 만들어 API 연동을 전담하도록 수정하였습니다.
에러 발생 시 전체 페이지가 ErrorPage로 전환되는 UX 문제를 개선하기 위해, 에러 바운더리 범위를 축소했습니다.

## 🙋🏻‍♂️ Request
서버 쪽 수정이 필요한 부분이 있어 일단 Draft 상태로 올리고 다른 작업 진행할게용. 서버 수정 후 프론트 코드를 보완하고 Draft를 풀 예정입니다.

<!--
## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
-->
