### PR TITLE
Fix: 번호팅 연속된 POST 요청 수정

### DIFF
--- a/src/pages/login-callback/login-callback.tsx
+++ b/src/pages/login-callback/login-callback.tsx
@@ -3,10 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 
 import { routePath } from '@router/path';
 
-import {
-  postBlindMatchMyInfo,
-  getBlindMatchMyInfo,
-} from '@pages/blind-match/apis/queries';
+import { postBlindMatchMyInfo } from '@pages/blind-match/apis/queries';
 
 import { tokenService } from '@shared/auth/services/token-service';
 
@@ -37,9 +34,6 @@ const LoginCallback = () => {
     (async () => {
       try {
         await postBlindMatchMyInfo();
-        const data = await getBlindMatchMyInfo();
-        console.log('blind-match myget:', data);
-
         navigate(returnTo, { replace: true });
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
## 💬 Describe

> - #195 

제가 프로필 생성 POST 요청을 카카오 로그인 끝나고 홈화면 렌더링 후에 보내도록 로직을 짜서 새로고침이나 다른 페이지 이동후에 돌아와도 계속 POST 요청을 보내는 오류가 발생해 ``useMemo``사용해 한번만 보내도록 수정했습니다.

## 📑 Task
- usememo 사용해 로직 수정

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->

<!--
## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
-->
