### PR TITLE
HOTFIX: 배포 관리자 페이지 404에러 관련

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 💬 Describe

> - #199 

해당 PR에 대해 설명해 주세요.
- vercel.json 추가

## 📑 Task
Vercel에서 SPA 라우팅을 위한 fallback 설정이 없어서 /admin-login 같은 클라이언트 사이드 라우트를 인식하지 못하고 있습니다.
- 로컬: Vite 개발 서버가 자동으로 SPA fallback 처리
- 배포: Vercel이 실제 파일이 없는 경로에 대해 404 반환
따라서 vercel.json 파일 추가했습니다.
