### PR TITLE
QA-1 메인 페이지 오타 수정

### DIFF
--- a/src/shared/constants/festivalSchedule.ts
+++ b/src/shared/constants/festivalSchedule.ts
@@ -3,6 +3,6 @@ export const HOME_TEXT = {
   NOTICE: '공지사항',
   FESTIVAL_PERIOD: '축제 기간 (9/23 ~ 9/25)',
   TODAY_FESTIVAL_SCHEDULE: '오늘의 축제 일정',
-  TODAY_FESTIVAL_SCHEDULE_DETAIL: '금일의 축제 정보입니다.',
+  TODAY_FESTIVAL_SCHEDULE_DETAIL: '금일 축제 정보입니다.',
   FESTIVAL_DAY: ['1일차', '2일차', '3일차'],
 };


### PR DESCRIPTION
## 💬 Describe

> - #211 
기존 내용과 다른 메인 페이지의 일정 설명 부분을 수정하였습니다.

## 📑 Task
share > constants > festivalSchedule.ts 의 `TODAY_FESTIVAL_SCHEDULE_DETAIL` 을 수정하였습니다.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot

<img width="170" height="68" alt="image" src="https://github.com/user-attachments/assets/f5645350-9166-4b19-a796-7f2a5b9da5ea" />

