### PR TITLE
QA-1: 번호팅 상단 텍스트 오타 수정

### DIFF
--- a/src/pages/blind-match/blind-match.tsx
+++ b/src/pages/blind-match/blind-match.tsx
@@ -26,13 +26,13 @@ const BlindMatch = () => {
           </Tab.List>
           <Tab.Panels>
             <Tab.Panel value="day-1">
-              <ApplyPage currentDay="1일차 매칭" />
+              <ApplyPage currentDay="1일차" />
             </Tab.Panel>
             <Tab.Panel value="day-2">
-              <ApplyPage currentDay="2일차 매칭" />
+              <ApplyPage currentDay="2일차" />
             </Tab.Panel>
             <Tab.Panel value="day-3">
-              <ApplyPage currentDay="3일차 매칭" />
+              <ApplyPage currentDay="3일차" />
             </Tab.Panel>
           </Tab.Panels>
         </Tab.Container>

--- a/src/pages/blind-match/hooks/use-application.ts
+++ b/src/pages/blind-match/hooks/use-application.ts
@@ -23,10 +23,10 @@ export const useApplication = (currentDay: string) => {
   const [isSuccess, setIsSuccess] = useState(false);
 
   useEffect(() => {
-    if (currentDay === '1일차 매칭') {
+    if (currentDay === '1일차') {
       setHasApplied(true);
       setIsSuccess(false);
-    } else if (currentDay === '2일차 매칭') {
+    } else if (currentDay === '2일차') {
       setHasApplied(true);
       setIsSuccess(true);
     } else {
@@ -40,13 +40,13 @@ export const useApplication = (currentDay: string) => {
       const resultsTime = new Date();
 
       // 각 일차별 날짜 설정
-      if (currentDay === '1일차 매칭') {
+      if (currentDay === '1일차') {
         deadline.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_1);
         resultsTime.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_1);
-      } else if (currentDay === '2일차 매칭') {
+      } else if (currentDay === '2일차') {
         deadline.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_2);
         resultsTime.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_2);
-      } else if (currentDay === '3일차 매칭') {
+      } else if (currentDay === '3일차') {
         deadline.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_3);
         resultsTime.setFullYear(EVENT_YEAR, EVENT_MONTH, EVENT_DAYS.DAY_3);
       }


### PR DESCRIPTION
## 💬 Describe

> - #215 

번호팅 페이지 상단에 n일차 텍스트 부분의 중복 텍스트 문자를 해결합니다.

## 📑 Task
`blind-match.tsx` 파일과 `use-application.ts` 파일의 currentDay 값을 수정합니다.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot
<img width="283" height="101" alt="image" src="https://github.com/user-attachments/assets/f0127fe8-e2fd-46c5-8660-757805ca74dd" />


<img width="283" height="209" alt="image" src="https://github.com/user-attachments/assets/3d6474ff-5ce6-4af4-acb2-0be40e1bf3e5" />

