### PR TITLE
Fix: 번호팅 인풋창 한글 벤

### DIFF
--- a/src/pages/blind-match/components/use-info-form/use-info-form.tsx
+++ b/src/pages/blind-match/components/use-info-form/use-info-form.tsx
@@ -14,6 +14,8 @@ const USE_INFO_FORM = {
   INSTAR_ID: '인스타그램 ID를 입력하세요 (선택)',
 };
 
+const blockKorean = (s: string) => s.replace(/[^\x20-\x7E]/g, '');
+
 interface UseInfoFormProps {
   instaId: string;
   phoneNumber: string;
@@ -45,7 +47,8 @@ const UseInfoForm = ({
   }, [data?.result?.memberGender, gender, onGenderChange]);
 
   const handleInstaIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInstaIdChange(e.target.value);
+    const cleaned = blockKorean(e.target.value);
+    onInstaIdChange(cleaned);
   };
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 💬 Describe

> - #233 

번호팅 인스타 입력창에서 한글을 못 쓰게 막았습니다.
처음에 `` /[^\x00-\x7F]/g``이 정규식 사용했는데 이건 NULL, BEL, \n, 탭 등 다 허용해서 ESLint가 control character 들어갔다고 경고 띄워서 바꿨습니다.

## 📑 Task
- ``/[^\x20-\x7E]/g, ''`` 제어문자를 제외한 ASCII만 허용

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->

<!--
## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
-->
