### PR TITLE
QA-1: 온보딩 페이지 배경이랑 텍스트 겹치는 문제

### DIFF
--- a/src/pages/onboarding/onboarding.css.ts
+++ b/src/pages/onboarding/onboarding.css.ts
@@ -10,7 +10,7 @@ export const container = style({
   minHeight: '100dvh',
   alignItems: 'center',
   justifyContent: 'flex-end',
-  paddingBottom: 'clamp(14rem, 10vh, 10rem)',
+  paddingBottom: 'clamp(10rem, 10vh, 10rem)',
 });
 
 export const contentWrapper = style({


### PR DESCRIPTION
## 💬 Describe

> - #241 

## 📑 Task
온보딩 페이지 배경이랑 텍스트 겹치는 문제를 해결하였습니다.


## 📸 Screenshot
<img width="372" height="669" alt="image" src="https://github.com/user-attachments/assets/4a87d2a8-9b64-40c7-b033-f0d6e8878371" />
<img width="380" height="670" alt="image" src="https://github.com/user-attachments/assets/7a6fa4fc-5944-4805-ba10-9368c53312c3" />
