### PR TITLE
Fix: 분실물 등록 페이지 버튼&하단네비게이션 조정

### DIFF
--- a/src/pages/lost-item-report/lost-item-report.css.ts
+++ b/src/pages/lost-item-report/lost-item-report.css.ts
@@ -32,7 +32,3 @@ export const button = style({
   width: '100%',
   padding: '0 2.4rem',
 });
-
-export const container = style({
-  paddingBottom: '20rem',
-});

--- a/src/pages/lost-item-report/lost-item-report.css.ts
+++ b/src/pages/lost-item-report/lost-item-report.css.ts
@@ -32,3 +32,7 @@ export const button = style({
   width: '100%',
   padding: '0 2.4rem',
 });
+
+export const container = style({
+  paddingBottom: '20rem',
+});

--- a/src/pages/lost-item-report/lost-item-report.css.ts
+++ b/src/pages/lost-item-report/lost-item-report.css.ts
@@ -3,7 +3,6 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '@shared/styles';
 
 export const textInputContainer = style({
-  width: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
@@ -28,8 +27,8 @@ export const dropdownContainer = style({
 });
 
 export const button = style({
+  position: 'absolute',
+  bottom: '13.1rem',
   width: '100%',
   padding: '0 2.4rem',
-  position: 'fixed',
-  bottom: '5.8rem',
 });

--- a/src/shared/components/bottom-navigation/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation/bottom-navigation.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { routePath } from '@router/path';
@@ -21,8 +22,43 @@ const navItems = [
 ];
 
 const BottomNavigation = () => {
+  const [navBottom, setNavBottom] = useState('3rem');
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.visualViewport) {
+        const viewportHeight = window.visualViewport.height;
+        const innerHeight = window.innerHeight;
+        const keyboardHeight = innerHeight - viewportHeight;
+
+        if (keyboardHeight > 0) {
+          setNavBottom('-100px');
+        } else {
+          setNavBottom('3rem');
+        }
+      }
+    };
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', handleResize);
+    } else {
+      window.addEventListener('resize', handleResize);
+    }
+
+    return () => {
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', handleResize);
+      } else {
+        window.removeEventListener('resize', handleResize);
+      }
+    };
+  }, []);
+
   return (
-    <nav className={styles.navBar}>
+    <nav
+      className={styles.navBar}
+      style={{ bottom: navBottom }}
+    >
       <ul className={styles.navList}>
         {navItems.map((item) => (
           <li key={item.path}>


### PR DESCRIPTION
## 💬 Describe

> - #224

해당 PR에 대해 설명해 주세요.
버튼과 하단네비게이션 겹치는 현상 수정

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.
- keyboardHeight가 0보다 클 경우, 하단바의 bottom CSS 속성을 100px로 설정하여 키보드가 열렸을 시 사라지도록 했습니다.

- 하단바와 버튼 이 겹치는 현상이 생겨 버튼 위치 조정했습니다.


## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
모바일로 localhost들어가 확인하려했는데 카카오로그인 하고 안넘어가는 2슈 그리고 모바일에서 관리자 로그인이 안되는 이shu로 인해 테스트하지 못 했 습니다. 저런,(input이 있는 어느 페이지에서 확인하려해도 로그인 넘어야해서 어디서든 시도하지 못했습니다.

또, 분실물 등록 페이지 하단 네비게이션바 제외하고 싶은데 어떻게하나요. 추적추적했는데 어디서 바뀐건지 못찾겠습니다. 저로선 no해결 도와줘요~!~!~~!~!


## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="267" height="484" alt="image" src="https://github.com/user-attachments/assets/c3537d12-ec74-4b42-a22c-6f48e4ce2375" />

