### PR TITLE
Feat: 번호팅 복귀 폼 유지

### DIFF
--- a/src/pages/blind-match/components/agreement/agreement.tsx
+++ b/src/pages/blind-match/components/agreement/agreement.tsx
@@ -9,9 +9,10 @@ import * as styles from './agreement.css';
 interface AgreementProps {
   checked: boolean;
   onChange: (isAgreed: boolean) => void;
+  navState?: unknown;
 }
 
-const Agreement = ({ checked, onChange }: AgreementProps) => {
+const Agreement = ({ checked, onChange, navState }: AgreementProps) => {
   return (
     <div className={styles.agreementoption}>
       <AgreementOption
@@ -19,6 +20,7 @@ const Agreement = ({ checked, onChange }: AgreementProps) => {
         navigateTo={routePath.INFO_SHARE_CONSENT}
         checked={checked}
         onChange={onChange}
+        navState={navState}
       />
     </div>
   );

--- a/src/pages/blind-match/components/entry/entry.tsx
+++ b/src/pages/blind-match/components/entry/entry.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import {
   patchBlindMatchInfoStorage,
@@ -44,6 +45,8 @@ const EntryForm = ({ currentDay, onApplicationComplete }: EntryFormProps) => {
   const [agreed, setAgreed] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
+  const location = useLocation();
+  const navState = { form, agreed };
 
   const { data } = useQuery(
     BLIND_MATCH_QUERY_OPTIONS.BLIND_MATCH_INFO_STORAGE(),
@@ -62,6 +65,14 @@ const EntryForm = ({ currentDay, onApplicationComplete }: EntryFormProps) => {
       onApplicationComplete();
     },
   });
+  useEffect(() => {
+    const s = location.state as {
+      form?: MatchingForm;
+      agreed?: boolean;
+    } | null;
+    if (s?.form) setForm(s.form);
+    if (typeof s?.agreed === 'boolean') setAgreed(s.agreed);
+  }, [location.state]);
 
   useEffect(() => {
     const phoneRegex = /^010-\d{4}-\d{4}$/;
@@ -149,6 +160,7 @@ const EntryForm = ({ currentDay, onApplicationComplete }: EntryFormProps) => {
         <Agreement
           checked={agreed}
           onChange={handleConsentChange}
+          navState={navState}
         />
         <Button
           onClick={handleApplyClick}

--- a/src/pages/info-share/info-share.css.ts
+++ b/src/pages/info-share/info-share.css.ts
@@ -9,12 +9,6 @@ export const container = style({
   padding: '3rem 0 0 3rem',
 });
 
-export const topNav = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-});
-
 export const title = style({
   ...themeVars.fontStyles.head_eb_22,
   color: themeVars.color.bg_white,

--- a/src/pages/info-share/info-share.css.ts
+++ b/src/pages/info-share/info-share.css.ts
@@ -9,6 +9,12 @@ export const container = style({
   padding: '3rem 0 0 3rem',
 });
 
+export const topNav = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
 export const title = style({
   ...themeVars.fontStyles.head_eb_22,
   color: themeVars.color.bg_white,

--- a/src/pages/info-share/info-share.tsx
+++ b/src/pages/info-share/info-share.tsx
@@ -4,34 +4,40 @@ import {
   CONSENT_TITLE,
 } from '@pages/info-share/constants/INFO_SHARE_CONSENT';
 
+import TopNavigation from '@shared/components/top-navigation/top-navigation';
+
 import * as styles from './info-share.css';
 
 const InfoShare = () => {
   return (
-    <article className={styles.container}>
-      <header>
-        <h1 className={styles.title}>{CONSENT_TITLE}</h1>
-        <p className={styles.subtitle}>{CONSENT_SUBTITLE}</p>
-      </header>
+    <>
+      <TopNavigation title="개인정보" />
+      <article className={styles.container}>
+        <div></div>
+        <header>
+          <h1 className={styles.title}>{CONSENT_TITLE}</h1>
+          <p className={styles.subtitle}>{CONSENT_SUBTITLE}</p>
+        </header>
 
-      <ol>
-        {CONSENT_CONTENT.map(({ id, TITLE, TEXT }) => (
-          <li key={id}>
-            <h2 className={styles.itemTitle}>{TITLE}</h2>
-            <ul>
-              {TEXT.map((text, i) => (
-                <li
-                  className={styles.text}
-                  key={i}
-                >
-                  {text}
-                </li>
-              ))}
-            </ul>
-          </li>
-        ))}
-      </ol>
-    </article>
+        <ol>
+          {CONSENT_CONTENT.map(({ id, TITLE, TEXT }) => (
+            <li key={id}>
+              <h2 className={styles.itemTitle}>{TITLE}</h2>
+              <ul>
+                {TEXT.map((text, i) => (
+                  <li
+                    className={styles.text}
+                    key={i}
+                  >
+                    {text}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      </article>
+    </>
   );
 };
 

--- a/src/pages/info-share/info-share.tsx
+++ b/src/pages/info-share/info-share.tsx
@@ -1,3 +1,7 @@
+import { useLocation } from 'react-router-dom';
+
+import { routePath } from '@router/path';
+
 import {
   CONSENT_CONTENT,
   CONSENT_SUBTITLE,
@@ -9,9 +13,14 @@ import TopNavigation from '@shared/components/top-navigation/top-navigation';
 import * as styles from './info-share.css';
 
 const InfoShare = () => {
+  const location = useLocation();
   return (
     <>
-      <TopNavigation title="개인정보" />
+      <TopNavigation
+        title="개인정보"
+        backTo={routePath.BLIND_MATCH}
+        backState={location.state}
+      />
       <article className={styles.container}>
         <div></div>
         <header>

--- a/src/shared/components/agreement-option/agreement-option.tsx
+++ b/src/shared/components/agreement-option/agreement-option.tsx
@@ -11,6 +11,7 @@ interface AgreementOptionProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   navigateTo: string;
+  navState?: unknown;
 }
 
 const AgreementOption = ({
@@ -18,6 +19,7 @@ const AgreementOption = ({
   checked: isChecked,
   onChange,
   navigateTo,
+  navState,
 }: AgreementOptionProps) => {
   const toggleCheck = () => {
     onChange(!isChecked);
@@ -39,7 +41,10 @@ const AgreementOption = ({
         <span className={style.labelText}>{label}</span>
       </div>
 
-      <NavLink to={navigateTo}>
+      <NavLink
+        to={navigateTo}
+        state={navState}
+      >
         <IcSvgArrowRight
           cursor="pointer"
           width="1.25rem"

--- a/src/shared/components/top-navigation/top-navigation.tsx
+++ b/src/shared/components/top-navigation/top-navigation.tsx
@@ -9,16 +9,25 @@ interface TopNavigationProps {
   title: ReactNode;
   rightIcon?: ReactNode;
   onRightClick?: () => void;
+  backTo?: string;
+  backState?: unknown;
 }
 
 const TopNavigation = ({
   title,
   rightIcon,
   onRightClick,
+  backTo,
+  backState,
 }: TopNavigationProps) => {
-  const navigation = useNavigate();
+  const navigate = useNavigate();
+
   const handleLeftClick = () => {
-    navigation(-1);
+    if (backTo) {
+      navigate(backTo, { state: backState });
+    } else {
+      navigate(-1);
+    }
   };
 
   return (
@@ -32,7 +41,9 @@ const TopNavigation = ({
           height="2.4rem"
         />
       </button>
+
       <h1 className={styles.title}>{title}</h1>
+
       <button
         onClick={onRightClick}
         className={styles.rightButton}


### PR DESCRIPTION
## 💬 Describe

> - #240 

``useLocation`` useLocation은 React Router가 제공하는 Hook 중 하나로 현재 사용자가 보고 있는 URL 정보(경로, 쿼리스트링, state 등)를 가져올 수 있게 해줍니다. 뒤로가기 버튼이 컴포넌트 안에 있기 때문에 컴포넌트부터 state 값을 올려서 사용하였습니다.
또한 정보 동의 체크도 유지되게 하였습니다.

## 📑 Task
- useLocation을 사용해 페이지 이동 시 state 전달
- EntryForm에서 입력값 form과 동의 상태 agreed를 state로 관리
- 개인정보 동의 페이지를 다녀온 후에도 기존 입력값이 유지되도록 개선

## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
더 좋은 구조 있으면 말씀해주세요

## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.

https://github.com/user-attachments/assets/63d61ba7-5172-4684-9f50-48b246bf1b28


