### PR TITLE
QA-1: 부스 페이지 카드 css 수정

### DIFF
--- a/src/pages/booth/components/booth-list.tsx
+++ b/src/pages/booth/components/booth-list.tsx
@@ -61,7 +61,8 @@ const BoothList = ({ selectedType }: BoothListProps) => {
         )
         .map((booth) => (
           <Card
-            type="lg"
+            type="sm"
+            descType="md"
             key={booth.id}
             title={booth.name}
             assignee={booth.department}

--- a/src/shared/components/card/card.css.ts
+++ b/src/shared/components/card/card.css.ts
@@ -63,10 +63,15 @@ export const description = recipe({
     overflow: 'hidden',
   },
   variants: {
-    type: {
+    descType: {
       sm: {
         ...themeVars.fontStyles.caption2_m_12,
         color: themeVars.color.gray_200,
+        padding: '0 1.1rem 3.4rem 1.5rem',
+      },
+      md: {
+        ...themeVars.fontStyles.caption2_m_12,
+        color: themeVars.color.gray_400,
         padding: '0 1.1rem 3.4rem 1.5rem',
       },
       lg: {

--- a/src/shared/components/card/card.tsx
+++ b/src/shared/components/card/card.tsx
@@ -7,6 +7,7 @@ interface CardProps {
   assignee?: string;
   description?: string;
   type: 'sm' | 'lg';
+  descType: 'sm' | 'md' | 'lg';
   alt?: string;
   onClick?: () => void;
   imgSrc?: string;
@@ -18,6 +19,7 @@ const Card = ({
   assignee,
   description,
   type,
+  descType,
   onClick,
   imgSrc,
   imgAlt,
@@ -33,7 +35,7 @@ const Card = ({
           {assignee && <p className={styles.assignee}>{assignee}</p>}
         </div>
         <div className={styles.descriptionContainer}>
-          <p className={styles.description({ type })}>{description}</p>
+          <p className={styles.description({ descType })}>{description}</p>
         </div>
       </div>
       <div className={styles.img}>

--- a/src/shared/components/timeTable/timeTable.tsx
+++ b/src/shared/components/timeTable/timeTable.tsx
@@ -50,6 +50,7 @@ const TimeTable = ({
           imgSrc={imgSrc}
           imgAlt={imgAlt}
           type="sm"
+          descType="sm"
           onClick={onClick}
         />
       </div>


### PR DESCRIPTION
## 💬 Describe

> - #226 

기존 디자인과 다르던 css 를 수정하였습니다.

## 📑 Task
`card.css.ts` 파일에서 description의 type 을 sm | md | lg 세 가지로 나누었습니다.
card를 사용하는 곳에서 description의 타입을 descType 으로 받아올 수 있도록 수정하였습니다.

```
    descType: {
      sm: {
        ...themeVars.fontStyles.caption2_m_12,
        color: themeVars.color.gray_200,
        padding: '0 1.1rem 3.4rem 1.5rem',
      },
      md: {
        ...themeVars.fontStyles.caption2_m_12,
        color: themeVars.color.gray_400,
        padding: '0 1.1rem 3.4rem 1.5rem',
      },
      lg: {
        ...themeVars.fontStyles.body1_r_15,
        color: themeVars.color.gray_400,
        padding: '0 1.1rem 4.1rem 1.6rem',
      },
    },
```

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot

<img width="344" height="202" alt="image" src="https://github.com/user-attachments/assets/3c65b57f-34a9-4004-a9a8-1c4ab85a9fe5" />

<img width="336" height="406" alt="image" src="https://github.com/user-attachments/assets/8d0bf3c0-73ac-47fd-aa52-e79ae56c7470" />

