### PR TITLE
HOTFIX: 번호팅 페이지 로직 수정 및 API boolean상태 추가

### DIFF
--- a/src/pages/blind-match/components/apply-after/complete.css.ts
+++ b/src/pages/blind-match/components/apply-after/complete.css.ts
@@ -44,6 +44,7 @@ export const button = style({
 
 export const notice = style({
   display: 'flex',
+  alignItems: 'center',
   gap: '0.3rem',
   paddingTop: '0.6rem',
   ...themeVars.fontStyles.button_r_12,

--- a/src/pages/blind-match/components/user-info/user-info.tsx
+++ b/src/pages/blind-match/components/user-info/user-info.tsx
@@ -2,7 +2,7 @@ import * as styles from './user-info.css';
 
 interface UserInfoProps {
   title: string;
-  instaId: string;
+  instaId?: string;
   phoneNumber: string;
 }
 
@@ -10,9 +10,11 @@ const UserInfo = ({ title, instaId, phoneNumber }: UserInfoProps) => {
   return (
     <div className={styles.container}>
       <p className={styles.infoTitle}>{title}</p>
-      <p className={styles.infoText}>
-        인스타그램 ID - <span className={styles.info}>{instaId}</span>
-      </p>
+      {instaId && (
+        <p className={styles.infoText}>
+          인스타그램 ID - <span className={styles.info}>{instaId}</span>
+        </p>
+      )}
       <p className={styles.infoText}>
         전화번호 - <span className={styles.info}>{phoneNumber}</span>
       </p>

--- a/src/pages/blind-match/constants/blind-match-time.ts
+++ b/src/pages/blind-match/constants/blind-match-time.ts
@@ -16,10 +16,10 @@ export const EVENT_DAYS = {
  */
 export const START_HOUR = 0; // 00:00부터 신청 가능
 export const START_MINUTE = 0;
-export const DEADLINE_HOUR = 18;
-export const DEADLINE_MINUTE = 20;
-export const RESULTS_HOUR = 18;
-export const RESULTS_MINUTE = 30;
+export const DEADLINE_HOUR = 23;
+export const DEADLINE_MINUTE = 5;
+export const RESULTS_HOUR = 23;
+export const RESULTS_MINUTE = 10;
 
 /**
  * 시간 포맷팅 유틸리티 함수

--- a/src/pages/blind-match/hooks/use-application.ts
+++ b/src/pages/blind-match/hooks/use-application.ts
@@ -90,7 +90,12 @@ export const useApplication = (currentDay: string) => {
       if (now.getTime() >= resultsTime.getTime()) {
         setViewState('results');
       } else if (now.getTime() > deadline.getTime()) {
-        setViewState('closed');
+        // 마감 시간 후: 신청 완료한 사람은 complete 유지, 신청 안한 사람은 closed
+        if (hasApplied) {
+          setViewState('complete');
+        } else {
+          setViewState('closed');
+        }
       } else if (now.getTime() >= startTime.getTime()) {
         // 신청 시간 이후에만 신청 완료 상태 확인
         if (isApplicationCompleted) {
@@ -105,7 +110,7 @@ export const useApplication = (currentDay: string) => {
     };
 
     checkStatus();
-  }, [currentDay, isApplicationCompleted]);
+  }, [currentDay, isApplicationCompleted, hasApplied]);
 
   /**
    * 매칭 결과에 따른 성공/실패 판단
@@ -122,13 +127,14 @@ export const useApplication = (currentDay: string) => {
   }, [matchResult]);
 
   /**
-   * 사용자 정보를 통한 계정 존재 여부 확인
-   * @description 서버에서 사용자 정보가 있으면 계정이 존재하는 것으로 간주
-   * 단, 번호팅 신청 여부는 매칭 결과로 판단
+   * 사용자 정보를 통한 신청 여부 확인
+   * @description 서버에서 memberApplied 필드로 신청 여부를 확인
    */
   useEffect(() => {
-    // 계정 존재 여부만 확인, 신청 완료 여부는 매칭 결과로 판단
-  }, [userInfo, currentDay]);
+    if (userInfo?.result?.memberApplied) {
+      setHasApplied(true);
+    }
+  }, [userInfo]);
 
   /**
    * 신청 완료 핸들러

--- a/src/shared/apis/types/schema.d.ts
+++ b/src/shared/apis/types/schema.d.ts
@@ -912,10 +912,10 @@ export interface components {
       parent?: unknown;
       id?: string;
       displayName?: string;
+      autowireCapableBeanFactory?: components['schemas']['AutowireCapableBeanFactory'];
       applicationName?: string;
       /** Format: int64 */
       startupDate?: number;
-      autowireCapableBeanFactory?: components['schemas']['AutowireCapableBeanFactory'];
       environment?: components['schemas']['Environment'];
       /** Format: int32 */
       beanDefinitionCount?: number;
@@ -1186,28 +1186,28 @@ export interface components {
       attributeNames?: unknown;
       contextPath?: string;
       initParameterNames?: unknown;
-      sessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
-      /** Format: int32 */
-      sessionTimeout?: number;
       servletRegistrations?: {
         [key: string]: components['schemas']['ServletRegistration'];
       };
+      sessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
+      /** Format: int32 */
+      sessionTimeout?: number;
+      defaultSessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
+      effectiveSessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
       jspConfigDescriptor?: components['schemas']['JspConfigDescriptor'];
       virtualServerName?: string;
       requestCharacterEncoding?: string;
       responseCharacterEncoding?: string;
+      filterRegistrations?: {
+        [key: string]: components['schemas']['FilterRegistration'];
+      };
+      sessionCookieConfig?: components['schemas']['SessionCookieConfig'];
       /** Format: int32 */
       effectiveMajorVersion?: number;
       /** Format: int32 */
       effectiveMinorVersion?: number;
       serverInfo?: string;
       servletContextName?: string;
-      filterRegistrations?: {
-        [key: string]: components['schemas']['FilterRegistration'];
-      };
-      sessionCookieConfig?: components['schemas']['SessionCookieConfig'];
-      defaultSessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
-      effectiveSessionTrackingModes?: ('COOKIE' | 'URL' | 'SSL')[];
     };
     ServletRegistration: {
       mappings?: string[];
@@ -1226,11 +1226,11 @@ export interface components {
       };
       /** @deprecated */
       comment?: string;
-      secure?: boolean;
       domain?: string;
+      httpOnly?: boolean;
+      secure?: boolean;
       /** Format: int32 */
       maxAge?: number;
-      httpOnly?: boolean;
     };
     TaglibDescriptor: {
       taglibURI?: string;
@@ -1267,6 +1267,7 @@ export interface components {
       memberGender?: 'MALE' | 'FEMALE';
       memberPhoneNumber?: string;
       memberInstagramId?: string;
+      memberApplied?: boolean;
     };
     BaseResponseListFoundItemResponse: {
       isSuccess?: boolean;


### PR DESCRIPTION
## 💬 Describe

> - #265 

## 📑 Task
- 버튼 스타일에 alignItems 속성 추가하여 느낌표 icon이 가운데 정렬 되도록 수정하였습니다.
- 인스타그램 ID를 작성하지 않은 사용자는 결과 발표 때 instaID를 렌더링 하지 않도록 수정하였습니다.

- 번호팅에 신청 + 매칭 성공한 사람은 서로의 번호와 인스타 아이디 렌더링
- 번호팅에 신청 + 매칭에 실패한 사람은 성사되지 않았다는 컴포넌트 렌더링
- 유저의 번호팅 신청 상태에 대한 boolean값을 서버에서 추가하여 프론트에서 사용, 이를 통해 신청한 후에 다른 페이지로 갔다가 돌아와도 신청되었다는 컴포넌트 렌더링

## 🙋🏻‍♂️ Request
23시에 3차 QA때 확인해야될것 같습니다.  그래서 사진은 첨부하지 못해요.. 잘 될거에요!

<!--
## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
-->
