### PR TITLE
QA-2: 응모권 캐러셀 너비 수정 및 API값 수정

### DIFF
--- a/src/pages/ticket/components/carousel/carousel.css.ts
+++ b/src/pages/ticket/components/carousel/carousel.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const carouselImage = style({
+  height: '21.4rem',
+  width: '100%',
+});

--- a/src/pages/ticket/components/carousel/carousel.tsx
+++ b/src/pages/ticket/components/carousel/carousel.tsx
@@ -3,17 +3,20 @@ import { useQuery } from '@tanstack/react-query';
 import Carousel from '@shared/components/carousel/carousel';
 import Loading from '@shared/components/loading/loading';
 
+import * as styles from './carousel.css';
 import { TICKET_QUERY_OPTIONS } from '../../apis/queries';
 
 interface TicketCarouselProps {
-  selectedLevel: number;
+  selectedDayNumber: number;
 }
 
-const TicketCarousel = ({ selectedLevel }: TicketCarouselProps) => {
-  const { data, isLoading, error } = useQuery(
-    TICKET_QUERY_OPTIONS.RAFFLE_PRIZES(selectedLevel),
-  );
+const TicketCarousel = ({ selectedDayNumber }: TicketCarouselProps) => {
+  // API에서 데이터 가져오기
+  const { data, isLoading, error } = useQuery({
+    ...TICKET_QUERY_OPTIONS.RAFFLE_PRIZES(selectedDayNumber),
+  });
 
+  // API 데이터 사용
   if (isLoading) {
     return (
       <Loading
@@ -37,6 +40,7 @@ const TicketCarousel = ({ selectedLevel }: TicketCarouselProps) => {
             key={prize.prizeId}
             src={prize.prizeImagePath}
             alt={prize.prizeName}
+            className={styles.carouselImage}
           />
         ))}
       </Carousel>

--- a/src/pages/ticket/constants/ticket-time.ts
+++ b/src/pages/ticket/constants/ticket-time.ts
@@ -1,0 +1,39 @@
+/**
+ * 티켓 이벤트 날짜 상수
+ * @description 2025년 9월 23, 24, 25일 3일간 진행
+ */
+export const EVENT_YEAR = 2025;
+export const EVENT_MONTH = 8; // 9월 (0-based index)
+export const EVENT_DAYS = {
+  DAY_1: 23,
+  DAY_2: 24,
+  DAY_3: 25,
+} as const;
+
+/**
+ * 현재 날짜가 이벤트 날짜 중 어느 날인지 확인하는 함수
+ * @returns 해당하는 DAY 값 (1, 2, 3) 또는 null
+ */
+export const getCurrentEventDay = (): number | null => {
+  // 실제 현재 날짜 사용
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  const currentMonth = currentDate.getMonth();
+  const currentDay = currentDate.getDate();
+
+  // 이벤트 연도와 월이 맞는지 확인
+  if (currentYear !== EVENT_YEAR || currentMonth !== EVENT_MONTH) {
+    return null;
+  }
+
+  // 현재 날짜가 이벤트 날짜 중 어느 것인지 확인
+  if (currentDay === EVENT_DAYS.DAY_1) {
+    return 1;
+  } else if (currentDay === EVENT_DAYS.DAY_2) {
+    return 2;
+  } else if (currentDay === EVENT_DAYS.DAY_3) {
+    return 3;
+  }
+
+  return null;
+};

--- a/src/pages/ticket/hooks/use-date-selection.ts
+++ b/src/pages/ticket/hooks/use-date-selection.ts
@@ -1,0 +1,61 @@
+import { useState, useCallback, useEffect } from 'react';
+
+import { getCurrentEventDay } from '../constants/ticket-time';
+
+export type EventDay = '1일차' | '2일차' | '3일차';
+
+export interface DateSelectionState {
+  selectedDate: EventDay;
+  selectedDayNumber: number; // API 호출용 숫자 (1, 2, 3)
+  setSelectedDate: (date: EventDay) => void;
+  isCurrentEventDay: boolean; // 현재 날짜가 이벤트 날짜인지 여부
+}
+
+/**
+ * 티켓 페이지에서 날짜 선택을 관리하는 훅
+ * @description 현재 날짜를 기반으로 자동으로 이벤트 날짜를 설정하고, API 호출용 숫자도 제공
+ */
+export const useDateSelection = (): DateSelectionState => {
+  // 현재 날짜가 이벤트 날짜인지 확인
+  const currentEventDay = getCurrentEventDay();
+  const isCurrentEventDay = currentEventDay !== null;
+
+  // 현재 이벤트 날짜가 있으면 해당 날짜를, 없으면 1일차를 기본값으로 설정
+  const getInitialDate = (): EventDay => {
+    if (currentEventDay === 1) return '1일차';
+    if (currentEventDay === 2) return '2일차';
+    if (currentEventDay === 3) return '3일차';
+    return '1일차';
+  };
+
+  const [selectedDate, setSelectedDate] = useState<EventDay>(getInitialDate());
+
+  // selectedDate를 기반으로 API 호출용 숫자 계산
+  const selectedDayNumber =
+    selectedDate === '1일차' ? 1 : selectedDate === '2일차' ? 2 : 3;
+
+  const handleSetSelectedDate = useCallback((date: EventDay) => {
+    setSelectedDate(date);
+  }, []);
+
+  // 현재 날짜가 변경되면 자동으로 업데이트
+  useEffect(() => {
+    const newCurrentEventDay = getCurrentEventDay();
+    if (newCurrentEventDay !== null) {
+      const newDate: EventDay =
+        newCurrentEventDay === 1
+          ? '1일차'
+          : newCurrentEventDay === 2
+            ? '2일차'
+            : '3일차';
+      setSelectedDate(newDate);
+    }
+  }, []);
+
+  return {
+    selectedDate,
+    selectedDayNumber,
+    setSelectedDate: handleSetSelectedDate,
+    isCurrentEventDay,
+  };
+};

--- a/src/pages/ticket/ticket.tsx
+++ b/src/pages/ticket/ticket.tsx
@@ -1,18 +1,21 @@
+import Caption from '@pages/ticket/components/caption/caption';
+import TicketCarousel from '@pages/ticket/components/carousel/carousel';
+import TicketChip from '@pages/ticket/components/chip/chip';
 import InputSection from '@pages/ticket/components/inpur-section/input-section';
+import TicketModal from '@pages/ticket/components/ticketmodal';
+import { useDateSelection } from '@pages/ticket/hooks/use-date-selection';
+import { useTicketForm } from '@pages/ticket/hooks/use-ticket-form';
 import Complete from '@pages/ticket-complete/ticket-complete';
 
 import Button from '@shared/components/button/button';
 import Header from '@shared/components/header/header';
 import Title from '@shared/components/title/title';
 
-import Caption from './components/caption/caption';
-import TicketCarousel from './components/carousel/carousel';
-import TicketChip from './components/chip/chip';
-import TicketModal from './components/ticketmodal';
-import { useTicketForm } from './hooks/use-ticket-form';
 import * as styles from './ticket.css';
 
 const Ticket = () => {
+  const { selectedDayNumber } = useDateSelection();
+
   const {
     form,
     modalType,
@@ -46,7 +49,7 @@ const Ticket = () => {
           />
         </div>
 
-        <TicketCarousel selectedLevel={selectedLevel} />
+        <TicketCarousel selectedDayNumber={selectedDayNumber} />
         <div className={styles.inputsection}>
           <TicketChip
             selectedLevel={selectedLevel}


### PR DESCRIPTION
## 💬 Describe

> - #267 

## 📑 Task
응모권 페이지 캐러셀 너비와 높이가 제대로 잡혀있지 않아 짤리는 문제를 해결하였습니다.
기존 캐러셀의 이미지가 Lv.1때 1일차, Lv.2때 2일차 이런식으로 이미지를 불러왔는데
level과 상관없이 해당 날짜의 이미지를 불러오도록 수정하였습니다.
23일 이전 -> 1일차 이미지
23일(당일) -> 1일차 이미지
24일 -> 2일차 이미지
25일 -> 3일차 이미지
이런식으로 렌더링되도록 Date객체로 현재 날짜를 기준으로 계산하도록 하였습니다.

## 🙋🏻‍♂️ Request
동영상에서 Lv.이 바뀌어도 이미지는 독립적으로 날짜에 맞게 변하는걸 표현해보았어요.
새로고침하는게 날짜 변경했을 때 입니다.

## 📸 Screenshot
![화면 기록 2025-09-14 오후 9 29 30](https://github.com/user-attachments/assets/24c751fc-11e4-4955-8569-3a3bc7bd01f4)
