### PR TITLE
QA-3 번호팅 신청 상태 관리, 매칭 후 결과 관리

### DIFF
--- a/src/pages/blind-match/constants/blind-match-time.ts
+++ b/src/pages/blind-match/constants/blind-match-time.ts
@@ -16,10 +16,10 @@ export const EVENT_DAYS = {
  */
 export const START_HOUR = 0; // 00:00부터 신청 가능
 export const START_MINUTE = 0;
-export const DEADLINE_HOUR = 23;
-export const DEADLINE_MINUTE = 17;
-export const RESULTS_HOUR = 23;
-export const RESULTS_MINUTE = 20;
+export const DEADLINE_HOUR = 17;
+export const DEADLINE_MINUTE = 30;
+export const RESULTS_HOUR = 18;
+export const RESULTS_MINUTE = 0;
 
 /**
  * 시간 포맷팅 유틸리티 함수

--- a/src/pages/blind-match/hooks/use-application.ts
+++ b/src/pages/blind-match/hooks/use-application.ts
@@ -133,6 +133,7 @@ export const useApplication = (currentDay: string) => {
   useEffect(() => {
     if (userInfo?.result?.memberApplied) {
       setHasApplied(true);
+      setIsApplicationCompleted(true); // 서버에서 신청 완료 상태 확인 시 로컬 상태도 업데이트
     }
   }, [userInfo]);
 

--- a/src/pages/blind-match/hooks/use-application.ts
+++ b/src/pages/blind-match/hooks/use-application.ts
@@ -86,8 +86,27 @@ export const useApplication = (currentDay: string) => {
       deadline.setHours(DEADLINE_HOUR, DEADLINE_MINUTE, 0, 0);
       resultsTime.setHours(RESULTS_HOUR, RESULTS_MINUTE, 0, 0);
 
-      // 시간에 따른 상태 결정
-      if (now.getTime() >= resultsTime.getTime()) {
+      // 현재 날짜가 매칭 날짜보다 지났으면 무조건 closed
+      const currentDate = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+      );
+      const matchingDate = new Date(
+        EVENT_YEAR,
+        EVENT_MONTH,
+        currentDay === '1일차'
+          ? EVENT_DAYS.DAY_1
+          : currentDay === '2일차'
+            ? EVENT_DAYS.DAY_2
+            : EVENT_DAYS.DAY_3,
+      );
+
+      if (currentDate.getTime() > matchingDate.getTime()) {
+        // 매칭 날짜가 지났으면 무조건 closed
+        setViewState('closed');
+      } else if (now.getTime() >= resultsTime.getTime()) {
+        // 결과 발표 시간 이후
         setViewState('results');
       } else if (now.getTime() > deadline.getTime()) {
         // 마감 시간 후: 신청 완료한 사람은 complete 유지, 신청 안한 사람은 closed


### PR DESCRIPTION
## 💬 Describe

> - #294 

- 번호팅 신청 상태 관리
- 매칭 후 결과 관리

## 📑 Task
매칭이 마감되고 하루가 지나면 서버에서 데이터가 삭제된다는 얘기를 듣고 하루가 지났을 때 전날 매칭에 성공했던 실패했던 마감되었다는 컴포넌트가 렌더링되도록 수정하였습니다.
매칭 신청 후 매칭 신청 상태 관리가 제대로 되어있지 않았던 부분을 수정하였습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/3f9daad2-8bc0-480d-9112-eabbdf0bbfce

