### PR TITLE
QA-3: 홈 페이지 축제 정보 일차 표기

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -54,7 +54,7 @@ const Home = () => {
         <div className={styles.festivalScheduleText}>
           <TitleInfo
             mainTitle={HOME_TEXT.TODAY_FESTIVAL_SCHEDULE}
-            subTitle={HOME_TEXT.TODAY_FESTIVAL_SCHEDULE_DETAIL}
+            subTitle={`${selectedDay}일차 ${HOME_TEXT.TODAY_FESTIVAL_SCHEDULE_DETAIL}`}
           />
         </div>
         <div className={styles.chipContainer}>

--- a/src/shared/constants/festivalSchedule.ts
+++ b/src/shared/constants/festivalSchedule.ts
@@ -3,6 +3,6 @@ export const HOME_TEXT = {
   NOTICE: '공지사항',
   FESTIVAL_PERIOD: '축제 기간 (9/23 ~ 9/25)',
   TODAY_FESTIVAL_SCHEDULE: '오늘의 축제 일정',
-  TODAY_FESTIVAL_SCHEDULE_DETAIL: '금일 축제 정보입니다.',
+  TODAY_FESTIVAL_SCHEDULE_DETAIL: ' 축제 정보입니다.',
   FESTIVAL_DAY: ['1일차', '2일차', '3일차'],
 };


### PR DESCRIPTION
## 💬 Describe

> - #296 

- 홈 페이지 축제 정보 일차 표기

## 📑 Task
홈 페이지 금일 축제 정보 입니다. 부분을 선택된 칩의 날짜와 동일한 텍스트가 뜨도록 수정하였습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/1910b571-b659-48b9-8115-6a16b7be7d27

