### PR TITLE
QA-3 공연 상세 정보 설명부 조건부 렌더링

### DIFF
--- a/src/pages/show-detail/show-detail.tsx
+++ b/src/pages/show-detail/show-detail.tsx
@@ -52,10 +52,12 @@ const ShowDetail = () => {
         title="소개"
         description={data?.introduction}
       />
-      <DetailDescription
-        title="설명"
-        songsData={data?.songs}
-      />
+      {data?.songs?.length && (
+        <DetailDescription
+          title="설명"
+          songsData={data.songs}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 💬 Describe

> - #298 

## 📑 Task
공연 상세 정보에서 서버에서 설명부분을 빈 배열로 보냈을 때 조건부로 렌더링 되도록 처리하였습니다.

## 📸 Screenshot
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/07996353-85bb-4872-b7af-88a3a129023a" />
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/bad7269f-5c8c-42dd-a2d4-de0a8e49d8e3" />
