### PR TITLE
QA-3:  부스 상세 정보에서만 ScrollRestoration 적용 안됨 문제 해결

### DIFF
--- a/src/pages/booth-detail/booth-detail.tsx
+++ b/src/pages/booth-detail/booth-detail.tsx
@@ -21,11 +21,7 @@ const BoothDetailPage = () => {
 
   return (
     <>
-      <TopNavigation
-        title={topNavigationTitle}
-        backTo="/booth"
-        backState={{ selectedType: boothType }}
-      />
+      <TopNavigation title={topNavigationTitle} />
 
       <Tab.Container initialValue="booth-info">
         <Tab.List>


### PR DESCRIPTION
## 💬 Describe

> - #301 

## 📑 Task
기존 부스 상세 정보 페이지에서만 ScrollRestoration 적용이 안되는 문제를 해결하였습니다.
ScrollRestoration는 브라우저의 히스토리 API를 기반으로 작동하여 사용자가 브라우저의 뒤로가기 버튼을 누르거나 navigate(-1)을 사용할 때 브라우저가 이전 페이지의 스크르롤 위치를 복원해줍니다.
하지만 부스 상세 정보 페이지에서는 코드가
```tsx
navigate("/booth", { state: { selectedType: boothType } });
```
이렇게 새로운 네비게이션으로 지정되어있어 브라우저 히스토리와는 별개로 새로운 페이지로 이동하기에 ScrollRestoration이 적용되지 않습니다.
따라

## 📸 Screenshot

https://github.com/user-attachments/assets/b9f371d0-4d8e-4b2b-a6e4-6c2db3df28b9

