### PR TITLE
QA-3: 응모권 페이지 안내 멘트 수정

### DIFF
--- a/src/pages/ticket/components/caption/caption.css.ts
+++ b/src/pages/ticket/components/caption/caption.css.ts
@@ -13,3 +13,8 @@ export const message = style({
   paddingTop: '0.3rem',
   marginBottom: '12rem',
 });
+
+export const infoText = style({
+  ...themeVars.fontStyles.button_r_12,
+  color: themeVars.color.bg_white,
+});

--- a/src/pages/ticket/components/caption/caption.tsx
+++ b/src/pages/ticket/components/caption/caption.tsx
@@ -2,11 +2,13 @@ import { IcSvgCaution } from '@shared/icons';
 
 import * as styles from './caption.css';
 
+const INFO_TEXT = '축제 기간 중 레벨별로 한 번만 응모할 수 있습니다.';
+
 const Caption = () => {
   return (
     <div className={styles.message}>
       <IcSvgCaution style={{ width: '1.2rem', height: '1.2rem' }} />
-      축제 기간 중 일차 별로 한 번만 응모할 수 있습니다.
+      <p className={styles.infoText}>{INFO_TEXT}</p>
     </div>
   );
 };


### PR DESCRIPTION
## 💬 Describe

> - #303 

## 📑 Task

- 응모권 페이지 응모하기 버튼 하단의 안내 멘트를 수정하였습니다.
기존 : 일차 별로
수정 후 : 레벨별로

그리고 멘트에 fontStyle이 지정되어있지 않은 부분을 수정하였습니다.

## 📸 Screenshot
<img width="431" height="831" alt="image" src="https://github.com/user-attachments/assets/3f313421-2fec-48ca-bc7e-11df4c3b1c98" />
