### PR TITLE
Fix: 응모권 하단 nav 유지

### DIFF
--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -17,7 +17,7 @@ export const routePath = {
   GENERATE_AUTH_KEY: '/generate-auth-key',
   INFO_SHARE_CONSENT: '/info-share-consent',
   LINDING: '/landing',
-  TICKET_ONBOARDING: 'ticket-onboarding',
+  TICKET_ONBOARDING: '/ticket-onboarding',
   ONBOARDING: '/onboarding',
 } as const;
 

--- a/src/shared/components/bottom-navigation/bottom-navigation.tsx
+++ b/src/shared/components/bottom-navigation/bottom-navigation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, matchPath } from 'react-router-dom';
 
 import { routePath } from '@router/path';
 
@@ -54,6 +54,26 @@ const BottomNavigation = () => {
     };
   }, []);
 
+  const isActiveNav = (path: string) => {
+    if (path === routePath.HOME) {
+      return !!matchPath(
+        { path: routePath.HOME, end: true },
+        location.pathname,
+      );
+    }
+
+    if (path === routePath.TICKET_ONBOARDING) {
+      return (
+        matchPath(
+          { path: routePath.TICKET_ONBOARDING, end: false },
+          location.pathname,
+        ) ||
+        matchPath({ path: routePath.TICKET, end: false }, location.pathname)
+      );
+    }
+    return !!matchPath({ path, end: false }, location.pathname);
+  };
+
   return (
     <nav
       className={styles.navBar}
@@ -64,7 +84,9 @@ const BottomNavigation = () => {
           <li key={item.path}>
             <NavLink
               to={item.path}
-              className={({ isActive }) => styles.navLinkRecipe({ isActive })}
+              className={() =>
+                styles.navLinkRecipe({ isActive: !!isActiveNav(item.path) })
+              }
             >
               <item.icon
                 width="2.4rem"


### PR DESCRIPTION
## 💬 Describe

> - #293 

matchPath는 react-router-dom에서 제공하는 유틸 함수입니다.
경로 문자열과 현재 URL을 비교해서 이 경로가 매치되는지 boolean이나 매칭 결과 객체를 돌려주는 역할을 합니다.
보니깐 응모권 온보딩만 아이콘이 켜지게 코드가 짜여져있었습니다. 따라서 matchPath 사용해서 수정했습니당

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.

<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->

## 📸 Screenshot
해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.
<img width="648" height="968" alt="image" src="https://github.com/user-attachments/assets/672f129a-0dbc-4420-86d0-48b41e8279bc" />

