### PR TITLE
QA-3: 홈/부스 페이지 Chip 상태 유지 (종결) 

### DIFF
--- a/src/pages/booth/booth.tsx
+++ b/src/pages/booth/booth.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
-
 import BoothList from '@pages/booth/components/booth-list';
 
 import Carousel from '@shared/components/carousel/carousel';
@@ -8,6 +5,7 @@ import Chip from '@shared/components/chip/chip';
 import Header from '@shared/components/header/header';
 import Title from '@shared/components/title/title';
 import TitlInfo from '@shared/components/title-info/title-info';
+import { usePersistedState } from '@shared/hooks/use-persisted-state';
 
 import * as styles from './booth.css';
 import {
@@ -20,10 +18,9 @@ import {
 const mokImages = ['/map1.png', '/map2.png'];
 
 const Booth = () => {
-  const location = useLocation();
-
-  const [selectedType, setSelectedType] = useState(
-    location.state?.selectedType || BOOTH_TYPES[0],
+  const [selectedType, setSelectedType] = usePersistedState(
+    'booth-selected-type',
+    BOOTH_TYPES[0],
   );
 
   return (

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { PERFORMANCE_QUERY_OPTIONS } from '@pages/home/apis/queries';
@@ -11,18 +10,25 @@ import TimeTable from '@shared/components/timeTable/timeTable';
 import Title from '@shared/components/title/title';
 import TitleInfo from '@shared/components/title-info/title-info';
 import { HOME_TEXT } from '@shared/constants/festivalSchedule';
+import { usePersistedState } from '@shared/hooks/use-persisted-state';
 
 import * as styles from './home.css';
 
 const mokImages = ['/info.png'];
 
 const Home = () => {
-  const [selectedDay, setSelectedDay] = useState(1);
   const navigate = useNavigate();
+  const [selectedDay, setSelectedDay] = usePersistedState('homeSelectedDay', 1);
+
   const { data } = useQuery(PERFORMANCE_QUERY_OPTIONS.PERFORMANCE_LIST());
 
   const handleClick = (id: number | undefined) => {
-    if (id) navigate(`/show-detail/${id}`);
+    if (id)
+      navigate(`/show-detail/${id}`, {
+        state: {
+          selectedDay,
+        },
+      });
   };
 
   return (

--- a/src/shared/hooks/use-persisted-state.ts
+++ b/src/shared/hooks/use-persisted-state.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * 페이지 간 상태를 유지하는 커스텀 훅
+ * @param key - 저장소에 사용할 키 (페이지별로 고유해야 함)
+ * @param defaultValue - 기본값
+ * @param storage - 사용할 저장소 (기본값: sessionStorage)
+ */
+export const usePersistedState = <T>(
+  key: string,
+  defaultValue: T,
+  storage: Storage = sessionStorage,
+) => {
+  const [state, setState] = useState<T>(() => {
+    // 저장소에서 값 가져오기
+    try {
+      const storedValue = storage.getItem(key);
+      if (storedValue !== null) {
+        return JSON.parse(storedValue);
+      }
+    } catch (error) {
+      console.warn(
+        `"${key}"에 대한 저장된 값을 파싱하는데 실패했습니다:`,
+        error,
+      );
+    }
+
+    // 기본값 사용
+    return defaultValue;
+  });
+
+  // 상태가 변경될 때 저장소에 저장
+  useEffect(() => {
+    try {
+      storage.setItem(key, JSON.stringify(state));
+    } catch (error) {
+      console.warn(`"${key}"에 값을 저장하는데 실패했습니다:`, error);
+    }
+  }, [key, state, storage]);
+
+  return [state, setState] as const;
+};


### PR DESCRIPTION
## 💬 Describe

> - #305 

해당 PR에 대해 설명해 주세요.
- 홈 / 부스 페이지 Chip 상태 유지

## 📑 Task
이전 PR에서 TopNavigation 컴포넌트로 뒤로가기를 했을 때 ScrollRestoration이 작동하지 안았던 문제를 해결하니 다시 Chip상태가 유지되지 않았어요. 그 이유는 기존 승택님 코드에서는 TopNavigationdml `backTo`와 `backState`를 이용해서 Chip 상태는 유지하는 방식이었는데 이 방식을 사용하면
- 그냥 뒤로가기 했을 때에만 ScrollRestoration이 적용되었지만 Chip상태는 유지 안됨.
- TopNavigation의 뒤로가기 버튼을 눌렀을 때에는 ScrollRestoration이 적용 안됨, Chip 상태는 유지 됨.
그래서 Chip상태를 어떻게 관리를 해야되지 생각하다가 전역으로 관리를 할까 싶다가 sessionStorage에 저장하는 방식을 생각했습니다. 부스나 홈에서 Chip을 선택하면 해당 chip의 카테고리가 sesstionStorage에 저장되고 상세 정보에 들어갔다 나와도 ScrollRestoration도 적용되고 Chip상태도록 하였습니당.

## 📸 Screenshot

https://github.com/user-attachments/assets/97785af2-7ba3-4b30-89ce-ca427b46e87d

