### PR TITLE
Fix: 당첨자 관리 로직 개선 및 상태 업데이트 방식 변경 및 인증키 새로고침 버튼 삭제

### DIFF
--- a/src/pages/admin/generate-auth-key/generate-auth-key.css.ts
+++ b/src/pages/admin/generate-auth-key/generate-auth-key.css.ts
@@ -35,8 +35,3 @@ export const authKey = style({
 
   borderRadius: '12px',
 });
-
-export const buttonContainer = style({
-  width: '15rem',
-  marginTop: '2rem',
-});

--- a/src/pages/admin/generate-auth-key/generate-auth-key.tsx
+++ b/src/pages/admin/generate-auth-key/generate-auth-key.tsx
@@ -7,7 +7,6 @@ import {
 } from '@pages/admin/apis/queries';
 import { TITLE } from '@pages/admin/constants/TITLE';
 
-import Button from '@shared/components/button/button';
 import DropDown from '@shared/components/drop-down/drop-down';
 import { IcSvgEntry } from '@shared/icons';
 
@@ -44,10 +43,6 @@ const GenerateAuthKey = () => {
     setLevelMutation.mutate(Number(level));
   };
 
-  const handleRefreshAuthKey = () => {
-    refetch();
-  };
-
   if (error) return <div>인증키를 불러오는데 실패했습니다.</div>;
 
   return (
@@ -71,9 +66,6 @@ const GenerateAuthKey = () => {
               />
             }
           />
-        </div>
-        <div className={styles.buttonContainer}>
-          <Button onClick={handleRefreshAuthKey}>인증키 새로고침</Button>
         </div>
       </div>
     </>

--- a/src/pages/admin/ticket-drawing/components/drawing-main/drawing-main.tsx
+++ b/src/pages/admin/ticket-drawing/components/drawing-main/drawing-main.tsx
@@ -12,26 +12,24 @@ import * as styles from './drawing-main.css';
 interface DrawingMainProps {
   currentDay: string;
   onExecuteRaffle: () => void;
-  onExecuteSecondRaffle: () => void;
-  winners: WinnerData[];
+  winner: WinnerData | null;
   isLoading: boolean;
 }
 
 const DrawingMain = ({
   currentDay,
   onExecuteRaffle,
-  onExecuteSecondRaffle,
-  winners,
+  winner,
   isLoading,
 }: DrawingMainProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [viewState, setViewState] = useState<'initial' | 'result'>('initial');
 
   useEffect(() => {
-    if (winners.length > 0) {
+    if (winner) {
       setViewState('result');
     }
-  }, [winners]);
+  }, [winner]);
 
   const handleOpenModal = () => {
     setIsModalOpen(true);
@@ -44,16 +42,14 @@ const DrawingMain = ({
   const handleCheck = () => {
     setIsModalOpen(false);
     setViewState('result');
-    onExecuteRaffle();
   };
 
   if (viewState === 'result') {
     return (
       <Drawing
-        winners={winners}
+        winner={winner}
         isLoading={isLoading}
         onReExecuteRaffle={onExecuteRaffle}
-        onExecuteSecondRaffle={onExecuteSecondRaffle}
       />
     );
   }

--- a/src/pages/admin/ticket-drawing/components/drawing/drawing.tsx
+++ b/src/pages/admin/ticket-drawing/components/drawing/drawing.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from 'react';
-
 import Loading from '@shared/components/loading/loading';
 import Title from '@shared/components/title/title';
 
@@ -8,26 +6,12 @@ import type { WinnerData } from '../../types/winner-data';
 import InfoSection from '../info-section/info-section';
 
 interface DrawingProps {
-  winners: WinnerData[];
+  winner: WinnerData | null;
   isLoading: boolean;
   onReExecuteRaffle: () => void;
-  onExecuteSecondRaffle: () => void;
 }
 
-const Drawing = ({
-  winners,
-  isLoading,
-  onReExecuteRaffle,
-  onExecuteSecondRaffle,
-}: DrawingProps) => {
-  const [displayWinners, setDisplayWinners] = useState<WinnerData[]>([]);
-
-  useEffect(() => {
-    if (winners.length > 0) {
-      setDisplayWinners(winners);
-    }
-  }, [winners]);
-
+const Drawing = ({ winner, isLoading, onReExecuteRaffle }: DrawingProps) => {
   return (
     <>
       <div className={styles.title}>
@@ -44,27 +28,14 @@ const Drawing = ({
         />
       ) : (
         <>
-          {/* 당첨자 1 - 항상 렌더링 */}
           <div className={styles.container}>
-            <p className={styles.text}>당첨자 1</p>
+            <p className={styles.text}>당첨자</p>
             <InfoSection
-              value={displayWinners[0]?.name || ''}
-              studentnumber={displayWinners[0]?.studentId || ''}
+              value={winner?.name || ''}
+              studentnumber={winner?.studentId || ''}
               handleButtonClick={onReExecuteRaffle}
             />
           </div>
-
-          {/* 당첨자 2 - 당첨자 1이 있을 때만 렌더링 */}
-          {displayWinners.length > 0 && (
-            <div className={styles.container}>
-              <p className={styles.text}>당첨자 2</p>
-              <InfoSection
-                value={displayWinners[1]?.name || ''}
-                studentnumber={displayWinners[1]?.studentId || ''}
-                handleButtonClick={onExecuteSecondRaffle}
-              />
-            </div>
-          )}
         </>
       )}
     </>

--- a/src/pages/admin/ticket-drawing/ticket-drawing.tsx
+++ b/src/pages/admin/ticket-drawing/ticket-drawing.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import {
   ADMIN_QUERY_OPTIONS,
@@ -11,80 +11,34 @@ import Tab from '@shared/components/tab/tab';
 import DrawingMain from './components/drawing-main/drawing-main';
 import type { WinnerData } from './types/winner-data';
 
-// localStorage 키 상수
-const STORAGE_KEYS = {
-  DAY1: 'ticket-drawing-day1-winners',
-  DAY2: 'ticket-drawing-day2-winners',
-  DAY3: 'ticket-drawing-day3-winners',
-  PREMIUM: 'ticket-drawing-premium-winners',
-};
-
 const TicketDrawing = () => {
-  // localStorage에서 데이터를 로드하는 함수
-  const loadWinnersFromStorage = (key: string): WinnerData[] => {
-    try {
-      const stored = localStorage.getItem(key);
-      return stored ? JSON.parse(stored) : [];
-    } catch (error) {
-      console.error(
-        `Failed to load winners from localStorage for key ${key}:`,
-        error,
-      );
-      return [];
-    }
-  };
+  const [day1Winner, setDay1Winner] = useState<WinnerData | null>(null);
+  const [day2Winner, setDay2Winner] = useState<WinnerData | null>(null);
+  const [day3Winner, setDay3Winner] = useState<WinnerData | null>(null);
+  const [premiumWinner, setPremiumWinner] = useState<WinnerData | null>(null);
 
-  // localStorage에 데이터를 저장하는 함수
-  const saveWinnersToStorage = (key: string, winners: WinnerData[]) => {
-    try {
-      localStorage.setItem(key, JSON.stringify(winners));
-    } catch (error) {
-      console.error(
-        `Failed to save winners to localStorage for key ${key}:`,
-        error,
-      );
-    }
-  };
-
-  const [day1Winners, setDay1Winners] = useState<WinnerData[]>([]);
-  const [day2Winners, setDay2Winners] = useState<WinnerData[]>([]);
-  const [day3Winners, setDay3Winners] = useState<WinnerData[]>([]);
-  const [premiumWinners, setPremiumWinners] = useState<WinnerData[]>([]);
-
-  // 컴포넌트 마운트 시 localStorage에서 데이터 로드
-  useEffect(() => {
-    setDay1Winners(loadWinnersFromStorage(STORAGE_KEYS.DAY1));
-    setDay2Winners(loadWinnersFromStorage(STORAGE_KEYS.DAY2));
-    setDay3Winners(loadWinnersFromStorage(STORAGE_KEYS.DAY3));
-    setPremiumWinners(loadWinnersFromStorage(STORAGE_KEYS.PREMIUM));
-  }, []);
-
-  const { data: day1Data, refetch: refetchDay1 } = useQuery({
+  const { refetch: refetchDay1 } = useQuery({
     ...ADMIN_QUERY_OPTIONS.RAFFLE_WINNERS(1),
   });
 
-  const { data: day2Data, refetch: refetchDay2 } = useQuery({
+  const { refetch: refetchDay2 } = useQuery({
     ...ADMIN_QUERY_OPTIONS.RAFFLE_WINNERS(2),
   });
 
-  const { data: day3Data, refetch: refetchDay3 } = useQuery({
+  const { refetch: refetchDay3 } = useQuery({
     ...ADMIN_QUERY_OPTIONS.RAFFLE_WINNERS(3),
   });
 
-  const { data: premiumData, refetch: refetchPremium } = useQuery({
+  const { refetch: refetchPremium } = useQuery({
     ...ADMIN_QUERY_OPTIONS.PREMIUM_RAFFLE_WINNERS(),
   });
 
   const executeDay1Mutation = useMutation({
     ...ADMIN_MUTATION_OPTIONS.EXECUTE_RAFFLE(),
     onSuccess: async () => {
-      await refetchDay1();
-      if (day1Data?.isSuccess && day1Data?.result) {
-        setDay1Winners((prev) => {
-          const newWinners = [...prev, day1Data.result!];
-          saveWinnersToStorage(STORAGE_KEYS.DAY1, newWinners);
-          return newWinners;
-        });
+      const { data: newData } = await refetchDay1();
+      if (newData?.isSuccess && newData?.result) {
+        setDay1Winner(newData.result);
       }
     },
   });
@@ -92,13 +46,9 @@ const TicketDrawing = () => {
   const executeDay2Mutation = useMutation({
     ...ADMIN_MUTATION_OPTIONS.EXECUTE_RAFFLE(),
     onSuccess: async () => {
-      await refetchDay2();
-      if (day2Data?.isSuccess && day2Data?.result) {
-        setDay2Winners((prev) => {
-          const newWinners = [...prev, day2Data.result!];
-          saveWinnersToStorage(STORAGE_KEYS.DAY2, newWinners);
-          return newWinners;
-        });
+      const { data: newData } = await refetchDay2();
+      if (newData?.isSuccess && newData?.result) {
+        setDay2Winner(newData.result);
       }
     },
   });
@@ -106,13 +56,9 @@ const TicketDrawing = () => {
   const executeDay3Mutation = useMutation({
     ...ADMIN_MUTATION_OPTIONS.EXECUTE_RAFFLE(),
     onSuccess: async () => {
-      await refetchDay3();
-      if (day3Data?.isSuccess && day3Data?.result) {
-        setDay3Winners((prev) => {
-          const newWinners = [...prev, day3Data.result!];
-          saveWinnersToStorage(STORAGE_KEYS.DAY3, newWinners);
-          return newWinners;
-        });
+      const { data: newData } = await refetchDay3();
+      if (newData?.isSuccess && newData?.result) {
+        setDay3Winner(newData.result);
       }
     },
   });
@@ -120,114 +66,28 @@ const TicketDrawing = () => {
   const executePremiumMutation = useMutation({
     ...ADMIN_MUTATION_OPTIONS.EXECUTE_PREMIUM_RAFFLE(),
     onSuccess: async () => {
-      await refetchPremium();
-      if (premiumData?.isSuccess && premiumData?.result) {
-        setPremiumWinners((prev) => {
-          const newWinners = [...prev, premiumData.result!];
-          saveWinnersToStorage(STORAGE_KEYS.PREMIUM, newWinners);
-          return newWinners;
-        });
+      const { data: newData } = await refetchPremium();
+      if (newData?.isSuccess && newData?.result) {
+        setPremiumWinner(newData.result);
       }
     },
   });
 
-  const handleReExecuteWinner1 = async (day: number) => {
-    if (day === 4) {
-      await executePremiumMutation.mutateAsync();
-      if (premiumData?.isSuccess && premiumData?.result) {
-        setPremiumWinners((prev) => {
-          const newWinners =
-            prev.length === 0
-              ? [premiumData.result!]
-              : [premiumData.result!, prev[1]];
-          saveWinnersToStorage(STORAGE_KEYS.PREMIUM, newWinners);
-          return newWinners;
-        });
-      }
-    } else {
-      const mutation =
-        day === 1
-          ? executeDay1Mutation
-          : day === 2
-            ? executeDay2Mutation
-            : executeDay3Mutation;
-      await mutation.mutateAsync(day);
-
-      const data = day === 1 ? day1Data : day === 2 ? day2Data : day3Data;
-      if (data?.isSuccess && data?.result) {
-        const setter =
+  const handleExecuteWinner = async (day: number) => {
+    try {
+      if (day === 4) {
+        await executePremiumMutation.mutateAsync();
+      } else {
+        const mutation =
           day === 1
-            ? setDay1Winners
+            ? executeDay1Mutation
             : day === 2
-              ? setDay2Winners
-              : setDay3Winners;
-        const storageKey =
-          day === 1
-            ? STORAGE_KEYS.DAY1
-            : day === 2
-              ? STORAGE_KEYS.DAY2
-              : STORAGE_KEYS.DAY3;
-
-        setter((prev) => {
-          const newWinners =
-            prev.length === 0 ? [data.result!] : [data.result!, prev[1]];
-          saveWinnersToStorage(storageKey, newWinners);
-          return newWinners;
-        });
+              ? executeDay2Mutation
+              : executeDay3Mutation;
+        await mutation.mutateAsync(day);
       }
-    }
-  };
-
-  const handleReExecuteWinner2 = async (day: number) => {
-    if (day === 4) {
-      await executePremiumMutation.mutateAsync();
-      if (premiumData?.isSuccess && premiumData?.result) {
-        setPremiumWinners((prev) => {
-          const newWinners =
-            prev.length === 0
-              ? [premiumData.result!]
-              : prev.length === 1
-                ? [...prev, premiumData.result!]
-                : [prev[0], premiumData.result!];
-          saveWinnersToStorage(STORAGE_KEYS.PREMIUM, newWinners);
-          return newWinners;
-        });
-      }
-    } else {
-      const mutation =
-        day === 1
-          ? executeDay1Mutation
-          : day === 2
-            ? executeDay2Mutation
-            : executeDay3Mutation;
-      await mutation.mutateAsync(day);
-
-      const data = day === 1 ? day1Data : day === 2 ? day2Data : day3Data;
-      if (data?.isSuccess && data?.result) {
-        const setter =
-          day === 1
-            ? setDay1Winners
-            : day === 2
-              ? setDay2Winners
-              : setDay3Winners;
-        const storageKey =
-          day === 1
-            ? STORAGE_KEYS.DAY1
-            : day === 2
-              ? STORAGE_KEYS.DAY2
-              : STORAGE_KEYS.DAY3;
-
-        setter((prev) => {
-          const newWinners =
-            prev.length === 0
-              ? [data.result!]
-              : prev.length === 1
-                ? [...prev, data.result!]
-                : [prev[0], data.result!];
-          saveWinnersToStorage(storageKey, newWinners);
-          return newWinners;
-        });
-      }
+    } catch {
+      // 에러 처리
     }
   };
 
@@ -244,36 +104,32 @@ const TicketDrawing = () => {
           <Tab.Panel value="1">
             <DrawingMain
               currentDay="1일차"
-              onExecuteRaffle={() => handleReExecuteWinner1(1)}
-              onExecuteSecondRaffle={() => handleReExecuteWinner2(1)}
-              winners={day1Winners}
+              onExecuteRaffle={() => handleExecuteWinner(1)}
+              winner={day1Winner}
               isLoading={executeDay1Mutation.isPending}
             />
           </Tab.Panel>
           <Tab.Panel value="2">
             <DrawingMain
               currentDay="2일차"
-              onExecuteRaffle={() => handleReExecuteWinner1(2)}
-              onExecuteSecondRaffle={() => handleReExecuteWinner2(2)}
-              winners={day2Winners}
+              onExecuteRaffle={() => handleExecuteWinner(2)}
+              winner={day2Winner}
               isLoading={executeDay2Mutation.isPending}
             />
           </Tab.Panel>
           <Tab.Panel value="3">
             <DrawingMain
               currentDay="3일차"
-              onExecuteRaffle={() => handleReExecuteWinner1(3)}
-              onExecuteSecondRaffle={() => handleReExecuteWinner2(3)}
-              winners={day3Winners}
+              onExecuteRaffle={() => handleExecuteWinner(3)}
+              winner={day3Winner}
               isLoading={executeDay3Mutation.isPending}
             />
           </Tab.Panel>
           <Tab.Panel value="4">
             <DrawingMain
               currentDay="Premium"
-              onExecuteRaffle={() => handleReExecuteWinner1(4)}
-              onExecuteSecondRaffle={() => handleReExecuteWinner2(4)}
-              winners={premiumWinners}
+              onExecuteRaffle={() => handleExecuteWinner(4)}
+              winner={premiumWinner}
               isLoading={executePremiumMutation.isPending}
             />
           </Tab.Panel>


### PR DESCRIPTION
## 💬 Describe

> - #316 

해당 PR에 대해 설명해 주세요.

## 📑 Task
- 관리자 응모권 추첨 페이지에서 응모권 모달 확인 하였을 때 POST가 요청되는 문제를 해결하였습니다.
- 관리자 응모권 추첨 페이지에서 당첨자를 2명에서 1명으로 변경하였습니다.
- 응모권 추첨 후 localStorage에 저장하도록 하였는데 저장되지 않도록 수정하였습니다. -> 일회성 유지
- 기존 응모권 추첨 로직에 있어 한명씩 밀리는 문제를 해결하였습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/2adc0f3e-25fd-4b25-91ca-510aa4ef8d32

https://github.com/user-attachments/assets/f78fd2fa-d735-4a76-a1aa-996bca3cd017


