### PR TITLE
Feat: Vercel 성능 지표 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.84.1",
     "@types/react-slick": "^0.23.13",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(react@19.1.1)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(react@19.1.1)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -1016,6 +1019,29 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -3682,6 +3708,10 @@ snapshots:
       - yaml
 
   '@vercel/analytics@1.5.0(react@19.1.1)':
+    optionalDependencies:
+      react: 19.1.1
+
+  '@vercel/speed-insights@1.2.0(react@19.1.1)':
     optionalDependencies:
       react: 19.1.1
 

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
@@ -8,5 +9,6 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
     <Analytics />
+    <SpeedInsights />
   </StrictMode>,
 );


### PR DESCRIPTION
## 💬 Describe

> - #335 

해당 PR에 대해 설명해 주세요.
성능 지표 추가하였습니다.

## 📑 Task
@vercel/speed-insights을 설치하고 main.tsx에 `<SpeedInsights />` 추가하여 Vercel에서 사용자의 실제 경험을 측정하는 성능 지표를 추가하였습니다.
