### PR TITLE
Fix: 한글입력시 ·가능하도록 수정

### DIFF
--- a/src/pages/ticket/components/inpur-section/input-section.tsx
+++ b/src/pages/ticket/components/inpur-section/input-section.tsx
@@ -23,7 +23,7 @@ const InputSection = ({
 }: InputSectionProps) => {
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    const koreanOnlyValue = value.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣]/g, '');
+    const koreanOnlyValue = value.replace(/[^ㄱ-ㅎㅏ-ㅣ가-힣·]/g, '');
     onNameChange(koreanOnlyValue);
   };
 


### PR DESCRIPTION
## 💬 Describe

> - #344

해당 PR에 대해 설명해 주세요.
천지연 키보드에서 한글 입력시 오류 수정했습니다.

## 📑 Task
해당 PR에서 진행한 작업 내용에 대해 작성해 주세요.
- 응모권 페이지  천지연 키보드 사용하여 이름을 입력할때 모음을 조합하기위해 ㆍ추가했습니다.
<img width="337" height="301" alt="image" src="https://github.com/user-attachments/assets/3662af73-1a1f-41a9-b46e-5cd74aa388ba" />


<!--
## 🙋🏻‍♂️ Request
리뷰어 혹은 팀에게 요청하고 싶은 사항이 있다면 작성해 주세요.
-->


## 📸 Screenshot

해당 작업에 대한 스크린샷 및 자료를 첨부해 주세요.

https://github.com/user-attachments/assets/c6f46f71-da1e-4a46-b85c-d5f3d0e90278