### PR TITLE
HOTFIX: 인스타그램 ID 유효성 검사 및 길이 제한 추가

### DIFF
--- a/src/pages/blind-match/components/use-info-form/use-info-form.tsx
+++ b/src/pages/blind-match/components/use-info-form/use-info-form.tsx
@@ -14,7 +14,7 @@ const USE_INFO_FORM = {
   INSTAR_ID: '인스타그램 ID를 입력하세요 (선택)',
 };
 
-const blockKorean = (s: string) => s.replace(/[^\x20-\x7E]/g, '');
+const validateInstagramId = (s: string) => s.replace(/[^a-zA-Z0-9._]/g, '');
 
 interface UseInfoFormProps {
   instaId: string;
@@ -47,8 +47,9 @@ const UseInfoForm = ({
   }, [data?.result?.memberGender, gender, onGenderChange]);
 
   const handleInstaIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const cleaned = blockKorean(e.target.value);
-    onInstaIdChange(cleaned);
+    const cleaned = validateInstagramId(e.target.value);
+    const limited = cleaned.slice(0, 30);
+    onInstaIdChange(limited);
   };
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 💬 Describe

> - #366 

해당 PR에 대해 설명해 주세요.

## 📑 Task
인스타 아이디 `영어`, `숫자`, `.`,  `_` 만 허용되도록 수정

